### PR TITLE
Feature/select assay in pull raw data

### DIFF
--- a/cubi_tk/snappy/models.py
+++ b/cubi_tk/snappy/models.py
@@ -9,7 +9,7 @@ from logzero import logger
 import yaml
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
 class SearchPattern:
     """Represent an entry in the ``search_patterns`` list."""
 
@@ -19,7 +19,7 @@ class SearchPattern:
     right: typing.Optional[str] = None
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
 class DataSet:
     """Represent a data set in the ``config.yaml`` file."""
 

--- a/cubi_tk/snappy/pull_raw_data.py
+++ b/cubi_tk/snappy/pull_raw_data.py
@@ -37,6 +37,7 @@ class Config:
     irsync_threads: int
     yes: bool
     project_uuid: str
+    assay: str
     samples: typing.List[str]
 
 
@@ -93,6 +94,10 @@ class PullRawDataCommand:
             help="Perform a dry run, i.e., don't change anything only display change, implies '--show-diff'.",
         )
         parser.add_argument("--irsync-threads", help="Parameter -N to pass to irsync")
+
+        parser.add_argument(
+            "--assay", dest="assay", default=None, help="UUID of assay to create landing zone for."
+        )
 
         parser.add_argument("project_uuid", help="UUID of project to download data for.")
 
@@ -153,6 +158,7 @@ class PullRawDataCommand:
                 irsync_threads=self.config.irsync_threads,
                 yes=self.config.yes,
                 project_uuid=self.config.project_uuid,
+                assay=self.config.assay,
                 output_dir=download_path,
             )
         ).execute()

--- a/cubi_tk/sodar/models.py
+++ b/cubi_tk/sodar/models.py
@@ -9,16 +9,16 @@ import typing
 import attr
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
 class OntologyTermRef:
     name: str
-    accession: typing.Optional[str]
-    ontology_name: typing.Optional[str]
+    accession: typing.Optional[str] = None
+    ontology_name: typing.Optional[str] = None
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
 class Assay:
-    sodar_uuid: typing.Optional[str]
+    sodar_uuid: typing.Optional[str] = None
     file_name: str
     irods_path: str
     technology_platform: str
@@ -27,9 +27,9 @@ class Assay:
     comments: typing.Dict[str, str]
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
 class Study:
-    sodar_uuid: typing.Optional[str]
+    sodar_uuid: typing.Optional[str] = None
     identifier: str
     file_name: str
     irods_path: str
@@ -39,9 +39,9 @@ class Study:
     assays: typing.Dict[str, Assay]
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
 class Investigation:
-    sodar_uuid: typing.Optional[str]
+    sodar_uuid: typing.Optional[str] = None
     archive_name: str
     comments: typing.Any
     description: str
@@ -50,7 +50,6 @@ class Investigation:
     irods_status: bool
     parser_version: str
     project: str
-    sodar_uuid: str
     studies: typing.Dict[str, Study]
     title: str
 
@@ -69,12 +68,12 @@ class User:
     email: str
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
 class LandingZone:
     """Represent a landing zone in the SODAR API."""
 
     #: UUID of the landing zone.
-    sodar_uuid: typing.Optional[str]
+    sodar_uuid: typing.Optional[str] = None
     #: Date of last modification.
     date_modified: str
 
@@ -95,8 +94,8 @@ class LandingZone:
     #: Status information string.
     status_info: str
     #: Optional configuration name.
-    configuration: typing.Optional[typing.Any]
+    configuration: typing.Optional[typing.Any] = None
     #: Optional configuration data.
-    config_data: typing.Optional[typing.Any]
+    config_data: typing.Optional[typing.Any] = None
     #: Path in iRODS.
     irods_path: str

--- a/cubi_tk/sodar/models.py
+++ b/cubi_tk/sodar/models.py
@@ -9,7 +9,7 @@ import typing
 import attr
 
 
-@attr.s(frozen=True, auto_attribs=True, kw_only=True)
+@attr.s(frozen=True, auto_attribs=True)
 class OntologyTermRef:
     name: str
     accession: typing.Optional[str] = None

--- a/cubi_tk/sodar/pull_raw_data.py
+++ b/cubi_tk/sodar/pull_raw_data.py
@@ -70,7 +70,7 @@ class LibraryInfoCollector(IsaNodeVisitor):
             self.samples[sample.name] = {
                 "source": self.sources[sample.name],
                 "library_name": library.name,
-                "folder_name": folder
+                "folder_name": folder,
             }
 
 
@@ -118,7 +118,7 @@ class PullRawDataCommand:
         parser.add_argument("--irsync-threads", help="Parameter -N to pass to irsync")
 
         parser.add_argument(
-            "--assay", dest="assay", default=None, help="UUID of assay to create landing zone for."
+            "--assay", dest="assay", default=None, help="UUID of assay to download data for."
         )
 
         parser.add_argument("project_uuid", help="UUID of project to download data for.")
@@ -165,7 +165,7 @@ class PullRawDataCommand:
             for assay_uuid in study.assays.keys():
                 if (self.config.assay is None) and (assay is None):
                     assay = study.assays[assay_uuid]
-                if (not self.config.assay is None) and (self.config.assay == assay_uuid):
+                if (self.config.assay is not None) and (self.config.assay == assay_uuid):
                     assay = study.assays[assay_uuid]
                     logger.info("Using irods path of assay %s: %s", assay_uuid, assay.irods_path)
                     break

--- a/cubi_tk/sodar/pull_raw_data.py
+++ b/cubi_tk/sodar/pull_raw_data.py
@@ -64,10 +64,13 @@ class LibraryInfoCollector(IsaNodeVisitor):
         elif material.type == "Library Name":
             library = material
             sample = material_path[0]
+            folder = first_value("Folder name", node_path)
+            if not folder:
+                folder = library.name
             self.samples[sample.name] = {
                 "source": self.sources[sample.name],
                 "library_name": library.name,
-                "folder_name": first_value("Folder name", node_path)
+                "folder_name": folder
             }
 
 


### PR DESCRIPTION
# Assay selection in `pull-raw-data`

- User can select a specific assay using the optional argument `--assay ASSAY` for the `cubi-tk sodar pull-raw-data` and `cubi-tk snappy pull-raw-data` commands. The behaviour for projects with a single assay is unchanged.
- The naming of arguments has been enforced for classes defined in `cubi_tk/sodar/models.py` and `cubi_tk/snappy/models.py`. This fixes `cattr.structure` problems when building new objects with optional arguments. A related problem was described [here](https://github.com/python-attrs/attrs/issues/93).
- The contents of the Isa-Tab assay `Library Name` column is a default when the `Folder Name` column is missing from that file.
