### PR TITLE
Use pedigree field during VarFish upload

### DIFF
--- a/cubi_tk/snappy/models.py
+++ b/cubi_tk/snappy/models.py
@@ -37,6 +37,8 @@ class DataSet:
     sodar_uuid: typing.Optional[str] = None
     #: The optional SODAR title.
     sodar_title: typing.Optional[str] = None
+    #: Field to be used to define pedigrees.
+    pedigree_field: typing.Optional[str] = None
 
 
 def load_config_yaml(path: pathlib.Path) -> typing.Any:

--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -40,14 +40,41 @@ PREFIXES = (
 
 
 def load_sheet_tsv(path_tsv, tsv_shortcut="germline"):
-    """Load sample sheet."""
+    """Load sample sheet.
+
+    :param path_tsv: Path to sample sheet TSV file.
+    :type path_tsv: pathlib.Path
+
+    :param tsv_shortcut: Sample sheet type. Default: 'germline'.
+    :type tsv_shortcut: str
+
+    :return: Returns Sheet model.
+    """
     load_tsv = getattr(io_tsv, "read_%s_tsv_sheet" % tsv_shortcut)
     with open(path_tsv, "rt") as f:
         return load_tsv(f, naming_scheme=NAMING_ONLY_SECONDARY_ID)
 
 
-def yield_ngs_library_names(sheet, min_batch=None, batch_key="batchNo"):
-    shortcut_sheet = shortcuts.GermlineCaseSheet(sheet)
+def yield_ngs_library_names(sheet, min_batch=None, batch_key="batchNo", pedigree_field=None):
+    """Yield DNA NGS library names for indexes.
+
+    :param sheet: Sample sheet.
+    :type sheet: biomedsheets.models.Sheet
+
+    :param min_batch: Minimum batch number to be extracted from the sheet. All samples in batches below this values
+    will be skipped.
+    :type min_batch: int
+
+    :param batch_key: Batch number key in sheet. Default: 'batchNo'.
+    :type batch_key: str
+
+    :param pedigree_field: Field that should be used to define a pedigree. If none is provided pedigree will be defined
+    based on information in the sample sheets rows alone.
+    """
+    kwargs = {}
+    if pedigree_field:
+        kwargs = {"join_by_field": pedigree_field}
+    shortcut_sheet = shortcuts.GermlineCaseSheet(sheet, **kwargs)
     for pedigree in shortcut_sheet.cohort.pedigrees:
         max_batch = max(donor.extra_infos.get(batch_key, 0) for donor in pedigree.donors)
         if min_batch is None or min_batch <= max_batch:
@@ -55,7 +82,7 @@ def yield_ngs_library_names(sheet, min_batch=None, batch_key="batchNo"):
 
 
 class SnappyVarFishUploadCommand:
-    """Implementation of snappy itransfer command for variant calling results."""
+    """Implementation of snappy varfish-upload command for variant calling results."""
 
     def __init__(self, args):
         #: Command line arguments.
@@ -175,11 +202,16 @@ class SnappyVarFishUploadCommand:
         if ds.sodar_uuid is None:
             raise TypeError("ds.sodar_uuid must not be null")
         sodar_uuid: str = ds.sodar_uuid
+        pedigree_field: str = ds.pedigree_field
         name = "%s (%s)" % (ds.sodar_title, sodar_uuid) if ds.sodar_title else sodar_uuid
         logger.info("Processing Dataset %s", name)
         logger.info("  loading from %s", self.args.base_path / ".snappy_pipeline" / ds.sheet_file)
-        sheet = load_sheet_tsv(self.args.base_path / ".snappy_pipeline" / ds.sheet_file)
-        for library in yield_ngs_library_names(sheet, self.args.min_batch):
+        sheet_path = self.args.base_path / ".snappy_pipeline" / ds.sheet_file
+        sheet = load_sheet_tsv(path_tsv=sheet_path)
+        ngs_library_names_list = yield_ngs_library_names(
+            sheet=sheet, min_batch=self.args.min_batch, pedigree_field=pedigree_field
+        )
+        for library in ngs_library_names_list:
             if self.args.samples and not library.split("-")[0] in self.args.samples.split(","):
                 logger.info("Skipping library %s as it is not included in --samples", library)
                 continue

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ toolz
 requests
 
 # Biomedsheet access.
-biomedsheets
+biomedsheets >=0.11.1
 
 # ISA-tab parsing.
 altamisa

--- a/tests/data/germline_sheet.tsv
+++ b/tests/data/germline_sheet.tsv
@@ -1,0 +1,15 @@
+[Custom Fields]
+key	annotatedEntity	docs	type	minimum	maximum	unit	choices	pattern
+batchNo	bioEntity	Batch No.	integer	.	.	.	.	.
+familyId	bioEntity	Family	string	.	.	.	.	.
+libraryKit	ngsLibrary	Enrichment kit	string	.	.	.	.	.
+
+[Data]
+familyId	patientName	fatherName	motherName	sex	isAffected	batchNo	libraryType	libraryKit	folderName	hpoTerms
+FAM_P001	P001	P002	P003	F	Y	1	WGS	Agilent SureSelect Human All Exon V6	P001	.
+FAM_P001	P002	.	.	M	N	1	WGS	Agilent SureSelect Human All Exon V6	P002	.
+FAM_P001	P003	.	.	F	N	1	WGS	Agilent SureSelect Human All Exon V6	P003	.
+FAM_P004	P004	P005	P006	M	Y	2	WGS	Agilent SureSelect Human All Exon V6	P004	.
+FAM_P004	P005	.	.	M	N	2	WGS	Agilent SureSelect Human All Exon V6	P005	.
+FAM_P004	P006	.	.	F	Y	2	WGS	Agilent SureSelect Human All Exon V6	P006	.
+FAM_P004	P007	.	.	F	Y	3	WGS	Agilent SureSelect Human All Exon V6	P007	.

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -1,0 +1,23 @@
+static_data_config: {}
+
+step_config: {}
+
+data_sets:
+  first_batch:
+    file: sheet.tsv
+    search_patterns:
+    - {'left': '*/*/*_R1.fastq.gz', 'right': '*/*/*_R2.fastq.gz'}
+    search_paths: ['/path']
+    type: germline_variants
+    naming_scheme: only_secondary_id
+    sodar_uuid: 99999999-aaaa-bbbb-cccc-999999999999
+    pedigree_field: familyId
+
+  second_batch:
+    file: sheet_wo.tsv
+    search_patterns:
+    - {'left': '*/*/*_R1.fastq.gz', 'right': '*/*/*_R2.fastq.gz'}
+    search_paths: ['/path']
+    type: germline_variants
+    naming_scheme: only_secondary_id
+    sodar_uuid: 99999999-dddd-eeee-ffff-999999999999

--- a/tests/test_snappy_models.py
+++ b/tests/test_snappy_models.py
@@ -1,0 +1,73 @@
+"""Tests for ``cubi_tk.snappy.models``."""
+import pathlib
+
+import pytest
+
+from cubi_tk.snappy.models import DataSet, SearchPattern, load_datasets
+
+
+@pytest.fixture
+def dataset_w_pedigree_field():
+    """
+    :return: Return model Dataset example with `pedigree_field` defined.
+    """
+    search_pattern = SearchPattern(left="*/*/*_R1.fastq.gz", right="*/*/*_R2.fastq.gz")
+    dataset = DataSet(
+        sheet_file="sheet.tsv",
+        sheet_type="germline_variants",
+        search_paths=("/path",),
+        search_patterns=(search_pattern,),
+        naming_scheme="only_secondary_id",
+        sodar_uuid="99999999-aaaa-bbbb-cccc-999999999999",
+        pedigree_field="familyId",
+    )
+    return dataset
+
+
+@pytest.fixture
+def dataset_wo_pedigree_field():
+    """
+    :return: Return model Dataset example without a defined `pedigree_field`.
+    """
+    search_pattern = SearchPattern(left="*/*/*_R1.fastq.gz", right="*/*/*_R2.fastq.gz")
+    dataset = DataSet(
+        sheet_file="sheet_wo.tsv",
+        sheet_type="germline_variants",
+        search_paths=("/path",),
+        search_patterns=(search_pattern,),
+        naming_scheme="only_secondary_id",
+        sodar_uuid="99999999-dddd-eeee-ffff-999999999999",
+    )
+    return dataset
+
+
+def test_dataset_w_fixture(dataset_w_pedigree_field):
+    """Testes dataset_w_pedigree_field()"""
+    ds = dataset_w_pedigree_field
+    assert isinstance(ds, DataSet)
+    assert ds.sheet_file == "sheet.tsv"
+    assert ds.naming_scheme == "only_secondary_id"
+    assert ds.sodar_uuid == "99999999-aaaa-bbbb-cccc-999999999999"
+    assert ds.pedigree_field == "familyId"
+
+
+def test_dataset_wo_fixture(dataset_wo_pedigree_field):
+    """Testes dataset_wo_pedigree_field()"""
+    ds = dataset_wo_pedigree_field
+    assert isinstance(ds, DataSet)
+    assert ds.sheet_file == "sheet_wo.tsv"
+    assert ds.naming_scheme == "only_secondary_id"
+    assert ds.sodar_uuid == "99999999-dddd-eeee-ffff-999999999999"
+    assert ds.pedigree_field is None
+
+
+def test_load_datasets(dataset_w_pedigree_field, dataset_wo_pedigree_field):
+    """Tests models.load_datasets()"""
+    # Define expected
+    expected = {"first_batch": dataset_w_pedigree_field, "second_batch": dataset_wo_pedigree_field}
+    # Define input
+    config_path = pathlib.Path(__file__).resolve().parent / "data" / "test_config.yaml"
+    # Get actual
+    actual = load_datasets(config_path)
+    assert len(actual) == 2, "Should return two datasets: 'first_batch' and 'second_batch'."
+    assert actual == expected

--- a/tests/test_snappy_varfish_upload.py
+++ b/tests/test_snappy_varfish_upload.py
@@ -1,0 +1,61 @@
+"""Tests for ``cubi_tk.snappy.varfish_upload``."""
+import pathlib
+
+from biomedsheets import models, shortcuts
+from biomedsheets.io_tsv import read_germline_tsv_sheet
+from biomedsheets.naming import NAMING_ONLY_SECONDARY_ID
+
+
+from cubi_tk.snappy.varfish_upload import load_sheet_tsv, yield_ngs_library_names
+
+
+def test_load_sheet_tsv():
+    """Tests varfish_upload.load_sheet_tsv()"""
+    # Define expected
+    expected_ngs_library_name_list = ["P001-N1-DNA1-WGS1", "P004-N1-DNA1-WGS1", "P007-N1-DNA1-WGS1"]
+
+    # Define input
+    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet.tsv"
+    # Get actual
+    sheet = load_sheet_tsv(path_tsv=sheet_path)
+    assert isinstance(sheet, models.Sheet)
+    # Convert to manageable format
+    shortcut_sheet = shortcuts.GermlineCaseSheet(sheet)
+    for pedigree in shortcut_sheet.cohort.pedigrees:
+        assert pedigree.index.dna_ngs_library.name in expected_ngs_library_name_list
+
+
+def test_yield_ngs_library_names():
+    """Tests varfish_upload.yield_ngs_library_names()"""
+    # Define expected
+    expected_batch_one = ["P001-N1-DNA1-WGS1"]
+    expected_batch_two = ["P004-N1-DNA1-WGS1"]
+    expected_batch_three = ["P007-N1-DNA1-WGS1"]
+    expected_ped_field_defined = expected_batch_one + expected_batch_two
+    expected_ped_field_none = expected_batch_one + expected_batch_two + expected_batch_three
+
+    # Define input
+    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet.tsv"
+    with open(sheet_path, "rt") as f_sheet:
+        sheet = read_germline_tsv_sheet(f=f_sheet, naming_scheme=NAMING_ONLY_SECONDARY_ID)
+
+    # Test `pedigree_field` = 'familyId'
+    actual = yield_ngs_library_names(sheet=sheet, pedigree_field="familyId")
+    for name_ in actual:
+        assert name_ in expected_ped_field_defined
+
+    # Test `pedigree_field` is None
+    actual = yield_ngs_library_names(sheet=sheet, pedigree_field=None)
+    for name_ in actual:
+        assert name_ in expected_ped_field_none
+
+    # Test `pedigree_field` is None and min batch = 2
+    actual = yield_ngs_library_names(sheet=sheet, pedigree_field=None, min_batch=2)
+    for name_ in actual:
+        expected_list = expected_batch_two + expected_batch_three
+        assert name_ in expected_list
+
+    # Test `pedigree_field` is None and min batch = 3
+    actual = yield_ngs_library_names(sheet=sheet, pedigree_field=None, min_batch=3)
+    for name_ in actual:
+        assert name_ in expected_batch_three


### PR DESCRIPTION
closes #46 

**Changes**
* Added possibility to use custom pedigree definition field also during VarFish upload.

**Tests**
* Tested with internal cohort. After changes there is no attempt to upload sibling data to VarFish, only index.