### PR TITLE
Improve itransfer subcommands

### DIFF
--- a/cubi_tk/snappy/common.py
+++ b/cubi_tk/snappy/common.py
@@ -95,7 +95,8 @@ def get_biomedsheet_path(start_path, uuid):
     snappy_config = snappy_dir_parent / ".snappy_pipeline" / "config.yaml"
 
     # Load config
-    config = yaml.safe_load(snappy_config)
+    with open(snappy_config, "r") as stream:
+        config = yaml.safe_load(stream)
 
     # Search config for the correct dataset
     for project in config["data_sets"]:
@@ -104,7 +105,7 @@ def get_biomedsheet_path(start_path, uuid):
             if dataset["sodar_uuid"] == uuid:
                 biomedsheet_path = snappy_dir_parent / ".snappy_pipeline" / dataset["file"]
         except KeyError:
-            # Not every dataset has an UUID associated
+            # Not every dataset has an associated UUID
             pass
 
     # Raise exception if none found

--- a/cubi_tk/snappy/common.py
+++ b/cubi_tk/snappy/common.py
@@ -106,14 +106,14 @@ def get_biomedsheet_path(start_path, uuid):
                 biomedsheet_path = snappy_dir_parent / ".snappy_pipeline" / dataset["file"]
         except KeyError:
             # Not every dataset has an associated UUID
+            logger.info("Data set '{0}' has no associated UUID.".format(project))
             pass
 
     # Raise exception if none found
     if biomedsheet_path is None:
+        tpl = "Could not find sample sheet for UUID {uuid}. Dataset configuration: {config}"
         config_str = "; ".join(["{} = {}".format(k, v) for k, v in config["data_sets"].items()])
-        msg = "Could not find sample sheet for UUID {uuid}. Dataset configuration: {config}".format(
-            uuid=uuid, config=config_str
-        )
+        msg = tpl.format(uuid=uuid, config=config_str)
         raise CouldNotFindBioMedSheet(msg)
 
     # Return path

--- a/cubi_tk/snappy/common.py
+++ b/cubi_tk/snappy/common.py
@@ -107,7 +107,6 @@ def get_biomedsheet_path(start_path, uuid):
         except KeyError:
             # Not every dataset has an associated UUID
             logger.info("Data set '{0}' has no associated UUID.".format(project))
-            pass
 
     # Raise exception if none found
     if biomedsheet_path is None:

--- a/cubi_tk/snappy/common.py
+++ b/cubi_tk/snappy/common.py
@@ -3,7 +3,10 @@
 import pathlib
 import typing
 
+from biomedsheets import io_tsv
+from biomedsheets.naming import NAMING_ONLY_SECONDARY_ID
 from logzero import logger
+import yaml
 
 
 #: Dependencies between the SNAPPY steps.
@@ -27,9 +30,25 @@ class CouldNotFindPipelineRoot(Exception):
     """Raised when ``.snappy_pipeline`` could not be found."""
 
 
+class CouldNotFindBioMedSheet(Exception):
+    """Raised when BioMedSheet could not be found in configuration file."""
+
+
 def find_snappy_root_dir(
     start_path: typing.Union[str, pathlib.Path], more_markers: typing.Iterable[str] = ()
 ):
+    """Find snappy pipeline root directory.
+
+    :param start_path: Start path to search for snappy root directory.
+    :type start_path: str, pathlib.Path
+
+    :param more_markers: Additional markers to be included in the search. Method will always use '.snappy_pipeline'.
+    :type more_markers: Iterable
+
+    :return: Returns path to snappy pipeline root directory.
+
+    :raises CouldNotFindPipelineRoot: if cannot find pipeline root.
+    """
     markers = [".snappy_pipeline"] + list(more_markers)
     start_path = pathlib.Path(start_path)
     for path in [start_path] + list(start_path.parents):
@@ -39,3 +58,62 @@ def find_snappy_root_dir(
             return path
     logger.error("Could not find SNAPPY pipeline directories below %s", start_path)
     raise CouldNotFindPipelineRoot()
+
+
+def load_sheet_tsv(path_tsv, tsv_shortcut="germline"):
+    """Load sample sheet.
+
+    :param path_tsv: Path to sample sheet TSV file.
+    :type path_tsv: pathlib.Path
+
+    :param tsv_shortcut: Sample sheet type. Default: 'germline'.
+    :type tsv_shortcut: str
+
+    :return: Returns Sheet model.
+    """
+    load_tsv = getattr(io_tsv, "read_%s_tsv_sheet" % tsv_shortcut)
+    with open(path_tsv, "rt") as f:
+        return load_tsv(f, naming_scheme=NAMING_ONLY_SECONDARY_ID)
+
+
+def get_biomedsheet_path(start_path, uuid):
+    """Get biomedsheet path, i.e., sample sheet.
+
+    :param start_path: Start path to search for snappy root directory.
+    :type start_path: str, pathlib.Path
+
+    :param uuid: Project UUID.
+    :type uuid: str
+
+    :return: Returns path to sample sheet.
+    """
+    # Initialise variables
+    biomedsheet_path = None
+
+    # Find config file
+    snappy_dir_parent = find_snappy_root_dir(start_path=start_path)
+    snappy_config = snappy_dir_parent / ".snappy_pipeline" / "config.yaml"
+
+    # Load config
+    config = yaml.safe_load(snappy_config)
+
+    # Search config for the correct dataset
+    for project in config["data_sets"]:
+        dataset = config["data_sets"].get(project)
+        try:
+            if dataset["sodar_uuid"] == uuid:
+                biomedsheet_path = snappy_dir_parent / ".snappy_pipeline" / dataset["file"]
+        except KeyError:
+            # Not every dataset has an UUID associated
+            pass
+
+    # Raise exception if none found
+    if biomedsheet_path is None:
+        config_str = "; ".join(["{} = {}".format(k, v) for k, v in config["data_sets"].items()])
+        msg = "Could not find sample sheet for UUID {uuid}. Dataset configuration: {config}".format(
+            uuid=uuid, config=config_str
+        )
+        raise CouldNotFindBioMedSheet(msg)
+
+    # Return path
+    return biomedsheet_path

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -182,7 +182,9 @@ class SnappyItransferCommandBase:
             action="store_true",
             help="After files are transferred to SODAR, it will proceed with validation and move.",
         )
-        parser.add_argument("destination", help="UUID from Landing Zone or Project - where files will be moved to.")
+        parser.add_argument(
+            "destination", help="UUID from Landing Zone or Project - where files will be moved to."
+        )
 
     @classmethod
     def run(

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -355,12 +355,11 @@ class SnappyItransferCommandBase:
     def get_sodar_info(self):
         """Method evaluates user input to extract or create iRODS path. Use cases:
 
-        1. User provides iRODS path. Same as before, use it.
-        2. User provides Landing Zone UUID. Same as before, fetch path and use it.
-        3. User provides Project UUID:
+        1. User provides Landing Zone UUID: fetch path and use it.
+        2. User provides Project UUID:
            i. If there are LZ associated with project, select the latest active and use it.
           ii. If there are no LZ associated with project, create a new one and use it.
-        4. Data provided by user is neither an iRODS path nor a valid UUID. Report error and throw exception.
+        3. Data provided by user is neither an iRODS path nor a valid UUID. Report error and throw exception.
 
         :return: Returns landing zone UUID and path to iRODS directory.
         """
@@ -371,13 +370,8 @@ class SnappyItransferCommandBase:
         create_lz_bool = self.args.yes
         in_destination = self.args.destination
 
-        # iRODS path provided by user
-        # Not possible to retrieve lz uuid from path. Returns None for lz_uuid.
-        if "/" in in_destination:
-            lz_irods_path = in_destination
-
         # Project UUID provided by user
-        elif is_uuid(in_destination):
+        if is_uuid(in_destination):
 
             if create_lz_bool:
                 # Assume that provided UUID is associated with a Project and user wants a new LZ.
@@ -479,9 +473,8 @@ class SnappyItransferCommandBase:
         # Not able to process - raise exception.
         # UUID provided is not associated with project nor lz.
         if lz_irods_path is None:
-            msg = (
-                "Data provided by user is neither an iRODS path nor a valid UUID. "
-                "Please review input: " + in_destination
+            msg = "Data provided by user is not a valid UUID. Please review input: {0}".format(
+                in_destination
             )
             logger.error(msg)
             raise ParameterException(msg)

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -182,7 +182,7 @@ class SnappyItransferCommandBase:
             action="store_true",
             help="After files are transferred to SODAR, it will proceed with validation and move.",
         )
-        parser.add_argument("destination", help="UUID or iRods path of landing zone to move to.")
+        parser.add_argument("destination", help="UUID from Landing Zone or Project - where files will be moved to.")
 
     @classmethod
     def run(

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -21,6 +21,7 @@ import tqdm
 
 from ..exceptions import MissingFileException, ParameterException, UserCanceledException
 from ..common import check_irods_icommands, is_uuid, load_toml_config, sizeof_fmt
+from .common import get_biomedsheet_path, load_sheet_tsv
 
 #: Default number of parallel transfers.
 DEFAULT_NUM_TRANSFERS = 8
@@ -82,17 +83,6 @@ def irsync_transfer(job: TransferJob, counter: Value, t: tqdm.tqdm):
 def check_args(args):
     """Argument checks that can be checked at program startup but that cannot be sensibly checked with ``argparse``."""
     _ = args
-
-
-def load_sheet_tsv(args):
-    """Load sample sheet."""
-    logger.info(
-        "Loading %s sample sheet from %s.",
-        args.tsv_shortcut,
-        getattr(args.biomedsheet_tsv, "name", "stdin"),
-    )
-    load_tsv = getattr(io_tsv, "read_%s_tsv_sheet" % args.tsv_shortcut)
-    return load_tsv(args.biomedsheet_tsv, naming_scheme=NAMING_ONLY_SECONDARY_ID)
 
 
 def load_sheets_tsv(args):
@@ -178,11 +168,6 @@ class SnappyItransferCommandBase:
             "--remote-dir-pattern",
             default="{library_name}/%s/{date}" % cls.step_name,
             help="Pattern to use for constructing remote pattern",
-        )
-        parser.add_argument(
-            "biomedsheet_tsv",
-            type=argparse.FileType("rt"),
-            help="Path to biomedsheets TSV file to load.",
         )
         parser.add_argument(
             "--yes",
@@ -642,17 +627,25 @@ class SnappyItransferCommandBase:
 
     def execute(self) -> typing.Optional[int]:
         """Execute the transfer."""
+        # Validate arguments
         res = self.check_args(self.args)
         if res:  # pragma: nocover
             return res
 
+        # Logger
         logger.info("Starting cubi-tk snappy %s", self.command_name)
         logger.info("  args: %s", self.args)
 
-        sheet = load_sheet_tsv(self.args)
+        # Find biomedsheet file
+        biomedsheet_tsv = get_biomedsheet_path(
+            start_path=self.args.base_path, uuid=self.args.destination
+        )
+
+        # Extract library names from sample sheet
+        sheet = load_sheet_tsv(biomedsheet_tsv, self.args.tsv_shortcut)
         library_names = list(
             self.yield_ngs_library_names(
-                sheet, min_batch=self.args.first_batch, max_batch=self.args.last_batch
+                sheet=sheet, min_batch=self.args.first_batch, max_batch=self.args.last_batch
             )
         )
         logger.info("Libraries in sheet:\n%s", "\n".join(sorted(library_names)))
@@ -698,8 +691,32 @@ class IndexLibrariesOnlyMixin:
     """Mixin for ``SnappyItransferCommandBase`` that only considers libraries of indexes."""
 
     def yield_ngs_library_names(
-        self, sheet, min_batch=None, batch_key="batchNo", family_key="familyId"
+        self, sheet, min_batch=None, max_batch=None, batch_key="batchNo", family_key="familyId"
     ):
+        """Yield index only NGS library names from sheet.
+
+        When ``min_batch`` is given then only the donors for which the ``extra_infos[batch_key]`` is greater than
+        ``min_batch`` will be used.
+
+        This function can be overloaded, for example to only consider the indexes.
+
+        :param sheet: Sample sheet.
+        :type sheet: biomedsheets.models.Sheet
+
+        :param min_batch: Minimum batch number to be extracted from the sheet. All samples in batches below this values
+        will be skipped.
+        :type min_batch: int
+
+        :param max_batch: Maximum batch number to be extracted from the sheet. All samples in batches above this values
+        will be skipped.
+        :type max_batch: int
+
+        :param batch_key: Batch number key in sheet. Default: 'batchNo'.
+        :type batch_key: str
+
+        :param family_key: Family identifier key. Default: 'familyId'.
+        :type family_key: str
+        """
         family_max_batch = self._build_family_max_batch(sheet, batch_key, family_key)
 
         shortcut_sheet = shortcuts.GermlineCaseSheet(sheet)
@@ -714,6 +731,16 @@ class IndexLibrariesOnlyMixin:
                         batch_key,
                         donor.extra_infos[batch_key],
                         min_batch,
+                    )
+                    continue
+            if max_batch is not None:
+                if batch > max_batch:
+                    logger.debug(
+                        "Skipping donor %s because %s = %d > max_batch = %d",
+                        donor.name,
+                        batch_key,
+                        donor.extra_infos[batch_key],
+                        max_batch,
                     )
                     continue
             logger.debug("Processing NGS library for donor %s", donor.name)

--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import typing
 
-from biomedsheets import io_tsv, shortcuts
+from biomedsheets import shortcuts
 from logzero import logger
 from varfish_cli.__main__ import main as varfish_cli_main
 

--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -7,10 +7,10 @@ import pathlib
 import typing
 
 from biomedsheets import io_tsv, shortcuts
-from biomedsheets.naming import NAMING_ONLY_SECONDARY_ID
 from logzero import logger
 from varfish_cli.__main__ import main as varfish_cli_main
 
+from .common import load_sheet_tsv
 from ..common import find_base_path
 from .models import DataSet, load_datasets
 
@@ -37,22 +37,6 @@ PREFIXES = (
     "bwa.xhmm",
     "write_pedigree",
 )
-
-
-def load_sheet_tsv(path_tsv, tsv_shortcut="germline"):
-    """Load sample sheet.
-
-    :param path_tsv: Path to sample sheet TSV file.
-    :type path_tsv: pathlib.Path
-
-    :param tsv_shortcut: Sample sheet type. Default: 'germline'.
-    :type tsv_shortcut: str
-
-    :return: Returns Sheet model.
-    """
-    load_tsv = getattr(io_tsv, "read_%s_tsv_sheet" % tsv_shortcut)
-    with open(path_tsv, "rt") as f:
-        return load_tsv(f, naming_scheme=NAMING_ONLY_SECONDARY_ID)
 
 
 def yield_ngs_library_names(sheet, min_batch=None, batch_key="batchNo", pedigree_field=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared fixtures for the unit tests"""
+import textwrap
+
+import pytest
+
+
+@pytest.fixture
+def minimal_config():
+    """Return configuration text"""
+    return textwrap.dedent(
+        r"""
+        static_data_config: {}
+
+        step_config: {}
+
+        data_sets:
+          first_batch:
+            sodar_uuid: 466ab946-ce6a-4c78-9981-19b79e7bbe86
+            file: sheet.tsv
+            search_patterns:
+            - {'left': '*/*/*_R1.fastq.gz', 'right': '*/*/*_R2.fastq.gz'}
+            search_paths: ['/path']
+            type: germline_variants
+            naming_scheme: only_secondary_id
+        """
+    ).lstrip()
+
+
+@pytest.fixture
+def germline_trio_sheet_tsv():
+    """Return contents for germline trio plus TSV file"""
+    return textwrap.dedent(
+        """
+        [Metadata]
+        schema\tgermline_variants
+        schema_version\tv1
+
+        [Custom Fields]
+        key\tannotatedEntity\tdocs\ttype\tminimum\tmaximum\tunit\tchoices\tpattern
+        batchNo\tbioEntity\tBatch No.\tinteger\t.\t.\t.\t.\t.
+        familyId\tbioEntity\tFamily\tstring\t.\t.\t.\t.\t.
+        projectUuid\tbioEntity\tProject UUID\tstring\t.\t.\t.\t.\t.
+        libraryKit\tngsLibrary\tEnrichment kit\tstring\t.\t.\t.\t.\t.
+
+        [Data]
+        familyId\tpatientName\tfatherName\tmotherName\tsex\tisAffected\tlibraryType\tfolderName\tbatchNo\thpoTerms\tprojectUuid\tseqPlatform\tlibraryKit
+        FAM_index\tindex\tfather\tmother\tM\tY\tWES\tindex\t1\t.\t466ab946-ce6a-4c78-9981-19b79e7bbe86\tIllumina\tAgilent SureSelect Human All Exons V6r2
+        FAM_index\tfather\t0\t0\tM\tN\tWES\tfather\t1\t.\t466ab946-ce6a-4c78-9981-19b79e7bbe86\tIllumina\tAgilent SureSelect Human All Exons V6r2
+        FAM_index\tmother\t0\t0\tF\tN\tWES\tmother\t1\t.\t466ab946-ce6a-4c78-9981-19b79e7bbe86\tIllumina\tAgilent SureSelect Human All Exons V6r2
+        """
+    ).lstrip()
+
+
+def my_exists(self):
+    """Method is used to patch pathlib.Path.exists"""
+    # self is the Path instance, str(Path) returns the path string
+    return str(self) == "/base/path/.snappy_pipeline"
+
+
+def my_get_sodar_info(_self):
+    """Method is used to patch cubi_tk.snappy.itransfer_common.SnappyItransferCommandBase.get_sodar_info"""
+    return "466ab946-ce6a-4c78-9981-19b79e7bbe86", "/irods/dest"

--- a/tests/data/find_snappy/.snappy_pipeline/config.yaml
+++ b/tests/data/find_snappy/.snappy_pipeline/config.yaml
@@ -1,0 +1,14 @@
+static_data_config: {}
+
+step_config: {}
+
+data_sets:
+  test_batch:
+    file: sheet.tsv
+    search_patterns:
+    - {'left': '*/*/*_R1.fastq.gz', 'right': '*/*/*_R2.fastq.gz'}
+    search_paths: ['/path']
+    type: germline_variants
+    naming_scheme: only_secondary_id
+    sodar_uuid: 99999999-aaaa-bbbb-cccc-999999999999
+    pedigree_field: familyId

--- a/tests/data/find_snappy/.snappy_pipeline/sheet.tsv
+++ b/tests/data/find_snappy/.snappy_pipeline/sheet.tsv
@@ -1,0 +1,14 @@
+[Custom Fields]
+key	annotatedEntity	docs	type	minimum	maximum	unit	choices	pattern
+familyId	bioEntity	Family	string	.	.	.	.	.
+libraryKit	ngsLibrary	Enrichment kit	string	.	.	.	.	.
+
+[Data]
+familyId	patientName	fatherName	motherName	sex	isAffected	libraryType	libraryKit	folderName	hpoTerms
+family1	P001	P002	P003	F	Y	WGS	Agilent SureSelect Human All Exon V6	P011	.
+family1	P002	.	.	M	N	WGS	Agilent SureSelect Human All Exon V6	P002	.
+family1	P003	.	.	F	N	WGS	Agilent SureSelect Human All Exon V6	P003	.
+family2	P004	P005	P006	M	Y	WGS	Agilent SureSelect Human All Exon V6	P004	.
+family2	P005	.	.	M	N	WGS	Agilent SureSelect Human All Exon V6	P005	.
+family2	P006	.	.	F	Y	WGS	Agilent SureSelect Human All Exon V6	P006	.
+family2	P007	.	.	F	Y	WGS	Agilent SureSelect Human All Exon V6	P007	.

--- a/tests/data/germline_sheet_multi_batch.tsv
+++ b/tests/data/germline_sheet_multi_batch.tsv
@@ -1,0 +1,22 @@
+[Custom Fields]
+key	annotatedEntity	docs	type	minimum	maximum	unit	choices	pattern
+batchNo	bioEntity	Batch No.	integer	.	.	.	.	.
+libraryKit	ngsLibrary	Enrichment kit	string	.	.	.	.	.
+
+[Data]
+patientName	fatherName	motherName	sex	isAffected	batchNo	libraryType	libraryKit	folderName	hpoTerms
+P001	P002	P003	F	Y	1	WGS	Agilent SureSelect Human All Exon V6	P001	.
+P002	.	.	M	N	1	WGS	Agilent SureSelect Human All Exon V6	P002	.
+P003	.	.	F	N	1	WGS	Agilent SureSelect Human All Exon V6	P003	.
+P004	P005	P006	M	Y	2	WGS	Agilent SureSelect Human All Exon V6	P004	.
+P005	.	.	M	N	2	WGS	Agilent SureSelect Human All Exon V6	P005	.
+P006	.	.	F	Y	2	WGS	Agilent SureSelect Human All Exon V6	P006	.
+P007	.	.	F	Y	3	WGS	Agilent SureSelect Human All Exon V6	P007	.
+P008	.	.	F	Y	3	WGS	Agilent SureSelect Human All Exon V6	P008	.
+P009	.	.	F	Y	3	WGS	Agilent SureSelect Human All Exon V6	P009	.
+P010	.	.	F	Y	4	WGS	Agilent SureSelect Human All Exon V6	P010	.
+P011	.	.	F	Y	4	WGS	Agilent SureSelect Human All Exon V6	P011	.
+P012	.	.	F	Y	4	WGS	Agilent SureSelect Human All Exon V6	P012	.
+P013	.	.	F	Y	5	WGS	Agilent SureSelect Human All Exon V6	P013	.
+P014	.	.	F	Y	5	WGS	Agilent SureSelect Human All Exon V6	P014	.
+P015	.	.	F	Y	6	WGS	Agilent SureSelect Human All Exon V6	P015	.

--- a/tests/test_snappy_common.py
+++ b/tests/test_snappy_common.py
@@ -1,0 +1,76 @@
+"""Tests for ``cubi_tk.snappy.common``."""
+import pathlib
+
+from biomedsheets import models, shortcuts
+
+import pytest
+
+from cubi_tk.snappy.common import (
+    CouldNotFindBioMedSheet,
+    CouldNotFindPipelineRoot,
+    find_snappy_root_dir,
+    get_biomedsheet_path,
+    load_sheet_tsv,
+)
+
+
+def test_could_not_find_pipeline_root_exception():
+    """Tests CouldNotFindPipelineRoot raise"""
+    with pytest.raises(CouldNotFindPipelineRoot):
+        raise CouldNotFindPipelineRoot()
+
+
+def test_could_not_find_biomedsheet_exception():
+    """Tests CouldNotFindPipelineRoot raise"""
+    with pytest.raises(CouldNotFindBioMedSheet):
+        raise CouldNotFindBioMedSheet()
+
+
+def test_find_snappy_root_dir():
+    """Tests find_snappy_root_dir()"""
+    # Define input
+    in_root_dir_present = pathlib.Path(__file__).resolve().parent / "data" / "find_snappy"
+    in_root_dir_absent = pathlib.Path(__file__).resolve().parent / "data" / "fastq_test"
+    # Positive test - directory contains '.snappy_pipeline'
+    actual = find_snappy_root_dir(start_path=in_root_dir_present)
+    assert actual is not None
+    # Negative test - directory should not be find
+    with pytest.raises(CouldNotFindPipelineRoot):
+        find_snappy_root_dir(start_path=in_root_dir_absent)
+
+
+def test_load_sheet_tsv():
+    """Tests load_sheet_tsv()"""
+    # Define expected
+    expected_ngs_library_name_list = ["P001-N1-DNA1-WGS1", "P004-N1-DNA1-WGS1", "P007-N1-DNA1-WGS1"]
+
+    # Define input
+    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet.tsv"
+
+    # Get actual
+    sheet = load_sheet_tsv(path_tsv=sheet_path)
+    assert isinstance(sheet, models.Sheet)
+
+    # Convert to manageable format
+    shortcut_sheet = shortcuts.GermlineCaseSheet(sheet)
+    for pedigree in shortcut_sheet.cohort.pedigrees:
+        assert pedigree.index.dna_ngs_library.name in expected_ngs_library_name_list
+
+
+def test_get_biomedsheet_path():
+    """Tests get_biomedsheet_path()"""
+    # Define input
+    uuid = "99999999-aaaa-bbbb-cccc-999999999999"
+    config_path = (
+        pathlib.Path(__file__).resolve().parent
+        / "data"
+        / "find_snappy"
+        / ".snappy_pipeline"
+        / "config.yaml"
+    )
+    # Positive test - UUID in config file
+    actual = get_biomedsheet_path(config_path, uuid)
+    assert actual is not None
+    # Negative test - should raise exception as UUID doesn't exist
+    with pytest.raises(CouldNotFindBioMedSheet):
+        get_biomedsheet_path(config_path, "123456")

--- a/tests/test_snappy_itransfer_common.py
+++ b/tests/test_snappy_itransfer_common.py
@@ -1,0 +1,91 @@
+"""Tests for ``cubi_tk.snappy.itransfer_common``."""
+import pathlib
+
+import pytest
+
+from biomedsheets.io_tsv import read_germline_tsv_sheet
+from biomedsheets.naming import NAMING_ONLY_SECONDARY_ID
+
+from cubi_tk.snappy.itransfer_common import SnappyItransferCommandBase
+
+
+@pytest.fixture
+def snappy_itransfer_command_base():
+    """Returns SnappyItransferCommandBase object"""
+    return SnappyItransferCommandBase(args=None)
+
+
+def test_yield_ngs_library_names(snappy_itransfer_command_base):
+    """Tests varfish_upload.yield_ngs_library_names()"""
+    # Define expected
+    expected_batch_one = ["P001-N1-DNA1-WGS1", "P002-N1-DNA1-WGS1", "P003-N1-DNA1-WGS1"]
+    expected_batch_two = ["P004-N1-DNA1-WGS1", "P005-N1-DNA1-WGS1", "P006-N1-DNA1-WGS1"]
+    expected_batch_three = ["P007-N1-DNA1-WGS1", "P008-N1-DNA1-WGS1", "P009-N1-DNA1-WGS1"]
+    expected_batch_four = ["P010-N1-DNA1-WGS1", "P011-N1-DNA1-WGS1", "P012-N1-DNA1-WGS1"]
+    expected_batch_five = ["P013-N1-DNA1-WGS1", "P014-N1-DNA1-WGS1"]
+    expected_batch_six = ["P015-N1-DNA1-WGS1"]
+
+    # Define input
+    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet_multi_batch.tsv"
+    with open(sheet_path, "rt") as f_sheet:
+        sheet = read_germline_tsv_sheet(f=f_sheet, naming_scheme=NAMING_ONLY_SECONDARY_ID)
+
+    # Sanity test - no constraints
+    actual = snappy_itransfer_command_base.yield_ngs_library_names(
+        sheet=sheet, min_batch=None, max_batch=None
+    )
+    expected_list = (
+        expected_batch_one
+        + expected_batch_two
+        + expected_batch_three
+        + expected_batch_four
+        + expected_batch_five
+        + expected_batch_six
+    )
+    for name_ in actual:
+        assert name_ in expected_list
+
+    # Test min batch = 2, max batch = None
+    actual = snappy_itransfer_command_base.yield_ngs_library_names(
+        sheet=sheet, min_batch=2, max_batch=None
+    )
+    expected_list = (
+        expected_batch_two
+        + expected_batch_three
+        + expected_batch_four
+        + expected_batch_five
+        + expected_batch_six
+    )
+    for name_ in actual:
+        assert name_ in expected_list
+    # Test min batch = 2, max batch = 3
+    actual = snappy_itransfer_command_base.yield_ngs_library_names(
+        sheet=sheet, min_batch=2, max_batch=3
+    )
+    expected_list = expected_batch_two + expected_batch_three
+    for name_ in actual:
+        assert name_ in expected_list
+
+    # Test min batch = 3, max batch = 5
+    actual = snappy_itransfer_command_base.yield_ngs_library_names(
+        sheet=sheet, min_batch=3, max_batch=5
+    )
+    expected_list = expected_batch_three + expected_batch_four + expected_batch_five
+    for name_ in actual:
+        assert name_ in expected_list
+
+    # Test min batch = 5, max batch = 5
+    actual = snappy_itransfer_command_base.yield_ngs_library_names(
+        sheet=sheet, min_batch=5, max_batch=5
+    )
+    expected_list = expected_batch_five
+    for name_ in actual:
+        assert name_ in expected_list
+
+    # Test min batch = 6, max batch = 6
+    actual = snappy_itransfer_command_base.yield_ngs_library_names(
+        sheet=sheet, min_batch=6, max_batch=6
+    )
+    expected_list = expected_batch_six
+    for name_ in actual:
+        assert name_ in expected_list

--- a/tests/test_snappy_itransfer_ngs_mapping.py
+++ b/tests/test_snappy_itransfer_ngs_mapping.py
@@ -10,6 +10,7 @@ from unittest.mock import ANY
 import pytest
 from pyfakefs import fake_filesystem
 
+from .conftest import my_exists, my_get_sodar_info
 from cubi_tk.__main__ import setup_argparse, main
 
 
@@ -38,8 +39,11 @@ def test_run_snappy_itransfer_ngs_mapping_nothing(capsys):
     assert res.err
 
 
-def test_run_snappy_itransfer_ngs_mapping_smoke_test(mocker):
+def test_run_snappy_itransfer_ngs_mapping_smoke_test(
+    mocker, germline_trio_sheet_tsv, minimal_config
+):
     fake_base_path = "/base/path"
+    dest_path = "/irods/dest"
     sodar_uuid = "466ab946-ce6a-4c78-9981-19b79e7bbe86"
     argv = [
         "--verbose",
@@ -73,8 +77,25 @@ def test_run_snappy_itransfer_ngs_mapping_smoke_test(mocker):
             )
             fs.create_file(fake_file_paths[-1])
 
+    # Create sample sheet in fake file system
+    sample_sheet_path = fake_base_path + "/.snappy_pipeline/sheet.tsv"
+    fs.create_file(sample_sheet_path, contents=germline_trio_sheet_tsv, create_missing_dirs=True)
+    # Create config in fake file system
+    config_path = fake_base_path + "/.snappy_pipeline/config.yaml"
+    fs.create_file(config_path, contents=minimal_config, create_missing_dirs=True)
+
+    # Print path to all created files
+    print("\n".join(fake_file_paths + [sample_sheet_path, config_path]))
+
     # Remove index's log MD5 file again so it is recreated.
     fs.remove(fake_file_paths[3])
+
+    # Set Mocker
+    mocker.patch("pathlib.Path.exists", my_exists)
+    mocker.patch(
+        "cubi_tk.snappy.itransfer_common.SnappyItransferCommandBase.get_sodar_info",
+        my_get_sodar_info,
+    )
 
     fake_os = fake_filesystem.FakeOsModule(fs)
     mocker.patch("glob.os", fake_os)
@@ -86,6 +107,7 @@ def test_run_snappy_itransfer_ngs_mapping_smoke_test(mocker):
 
     fake_open = fake_filesystem.FakeFileOpen(fs)
     mocker.patch("cubi_tk.snappy.itransfer_common.open", fake_open)
+    mocker.patch("cubi_tk.snappy.common.open", fake_open)
 
     mock_check_call = mock.mock_open()
     mocker.patch("cubi_tk.snappy.itransfer_common.check_call", mock_check_call)
@@ -121,7 +143,7 @@ def test_run_snappy_itransfer_ngs_mapping_smoke_test(mocker):
             path, os.path.join(fake_base_path, "ngs_mapping/output")
         ).split("/", 1)
         _mapper, index = mapper_index.rsplit(".", 1)
-        remote_path = os.path.join(sodar_uuid, index, "ngs_mapping", args.remote_dir_date, rel_path)
+        remote_path = os.path.join(dest_path, index, "ngs_mapping", args.remote_dir_date, rel_path)
         expected_mkdir_argv = ["imkdir", "-p", os.path.dirname(remote_path)]
         expected_irsync_argv = ["irsync", "-a", "-K", path, "i:%s" % remote_path]
         expected_ils_argv = ["ils", os.path.dirname(remote_path)]

--- a/tests/test_snappy_itransfer_ngs_mapping.py
+++ b/tests/test_snappy_itransfer_ngs_mapping.py
@@ -40,8 +40,7 @@ def test_run_snappy_itransfer_ngs_mapping_nothing(capsys):
 
 def test_run_snappy_itransfer_ngs_mapping_smoke_test(mocker):
     fake_base_path = "/base/path"
-    sodar_path = "sodar/path/to/landing/zone/landing_zone_uuid"
-    tsv_path = os.path.join(os.path.dirname(__file__), "data", "germline.out")
+    sodar_uuid = "466ab946-ce6a-4c78-9981-19b79e7bbe86"
     argv = [
         "--verbose",
         "snappy",
@@ -50,8 +49,7 @@ def test_run_snappy_itransfer_ngs_mapping_smoke_test(mocker):
         fake_base_path,
         "--sodar-api-token",
         "XXXX",
-        tsv_path,
-        sodar_path,
+        sodar_uuid,
     ]
 
     parser, subparsers = setup_argparse()
@@ -123,7 +121,7 @@ def test_run_snappy_itransfer_ngs_mapping_smoke_test(mocker):
             path, os.path.join(fake_base_path, "ngs_mapping/output")
         ).split("/", 1)
         _mapper, index = mapper_index.rsplit(".", 1)
-        remote_path = os.path.join(sodar_path, index, "ngs_mapping", args.remote_dir_date, rel_path)
+        remote_path = os.path.join(sodar_uuid, index, "ngs_mapping", args.remote_dir_date, rel_path)
         expected_mkdir_argv = ["imkdir", "-p", os.path.dirname(remote_path)]
         expected_irsync_argv = ["irsync", "-a", "-K", path, "i:%s" % remote_path]
         expected_ils_argv = ["ils", os.path.dirname(remote_path)]

--- a/tests/test_snappy_itransfer_variant_calling.py
+++ b/tests/test_snappy_itransfer_variant_calling.py
@@ -4,58 +4,14 @@ We only run some smoke tests here.
 """
 
 import os
-import textwrap
 from unittest import mock
 from unittest.mock import ANY
 
 import pytest
 from pyfakefs import fake_filesystem
 
+from .conftest import my_exists, my_get_sodar_info
 from cubi_tk.__main__ import setup_argparse, main
-
-
-@pytest.fixture
-def minimal_config():
-    """Return configuration text"""
-    return textwrap.dedent(
-        r"""
-        static_data_config: {}
-
-        step_config: {}
-
-        data_sets:
-          first_batch:
-            file: sheet.tsv
-            search_patterns:
-            - {'left': '*/*/*_R1.fastq.gz', 'right': '*/*/*_R2.fastq.gz'}
-            search_paths: ['/path']
-            type: germline_variants
-            naming_scheme: only_secondary_id
-        """
-    ).lstrip()
-
-
-@pytest.fixture
-def germline_trio_plus_sheet_tsv():
-    """Return contents for germline trio plus TSV file"""
-    return textwrap.dedent(
-        """
-        [Custom Fields]
-        key\tannotatedEntity\tdocs\ttype\tminimum\tmaximum\tunit\tchoices\tpattern
-        familyId\tbioEntity\tFamily\tstring\t.\t.\t.\t.\t.
-        libraryKit\tngsLibrary\tEnrichment kit\tstring\t.\t.\t.\t.\t.
-
-        [Data]
-        familyId\tpatientName\tfatherName\tmotherName\tsex\tisAffected\tlibraryType\tlibraryKit\tfolderName\thpoTerms
-        family1\tP001\tP002\tP003\tF\tY\tWGS\tAgilent SureSelect Human All Exon V6\tP011\t.
-        family1\tP002\t.\t.\tM\tN\tWGS\tAgilent SureSelect Human All Exon V6\tP002\t.
-        family1\tP003\t.\t.\tF\tN\tWGS\tAgilent SureSelect Human All Exon V6\tP003\t.
-        family2\tP004\tP005\tP006\tM\tY\tWGS\tAgilent SureSelect Human All Exon V6\tP004\t.
-        family2\tP005\t.\t.\tM\tN\tWGS\tAgilent SureSelect Human All Exon V6\tP005\t.
-        family2\tP006\t.\t.\tF\tY\tWGS\tAgilent SureSelect Human All Exon V6\tP006\t.
-        family2\tP007\t.\t.\tF\tY\tWGS\tAgilent SureSelect Human All Exon V6\tP007\t.
-        """
-    ).lstrip()
 
 
 def test_run_snappy_itransfer_variant_calling_help(capsys):
@@ -84,10 +40,11 @@ def test_run_snappy_itransfer_variant_calling_nothing(capsys):
 
 
 def test_run_snappy_itransfer_variant_calling_smoke_test(
-    mocker, minimal_config, germline_trio_plus_sheet_tsv
+    mocker, minimal_config, germline_trio_sheet_tsv
 ):
     fake_base_path = "/base/path"
-    dest_path = "466ab946-ce6a-4c78-9981-19b79e7bbe86"
+    dest_path = "/irods/dest"
+    sodar_uuid = "466ab946-ce6a-4c78-9981-19b79e7bbe86"
     argv = [
         "--verbose",
         "snappy",
@@ -97,7 +54,7 @@ def test_run_snappy_itransfer_variant_calling_smoke_test(
         "--sodar-api-token",
         "XXXX",
         # tsv_path,
-        dest_path,
+        sodar_uuid,
     ]
 
     # Setup fake file system but only patch selected modules.  We cannot use the Patcher approach here as this would
@@ -124,9 +81,7 @@ def test_run_snappy_itransfer_variant_calling_smoke_test(
             fs.create_file(fake_file_paths[-1])
     # Create sample sheet in fake file system
     sample_sheet_path = fake_base_path + "/.snappy_pipeline/sheet.tsv"
-    fs.create_file(
-        sample_sheet_path, contents=germline_trio_plus_sheet_tsv, create_missing_dirs=True
-    )
+    fs.create_file(sample_sheet_path, contents=germline_trio_sheet_tsv, create_missing_dirs=True)
     # Create config in fake file system
     config_path = fake_base_path + "/.snappy_pipeline/config.yaml"
     fs.create_file(config_path, contents=minimal_config, create_missing_dirs=True)
@@ -136,6 +91,13 @@ def test_run_snappy_itransfer_variant_calling_smoke_test(
 
     # Remove index's log MD5 file again so it is recreated.
     fs.remove(fake_file_paths[3])
+
+    # Set Mocker
+    mocker.patch("pathlib.Path.exists", my_exists)
+    mocker.patch(
+        "cubi_tk.snappy.itransfer_common.SnappyItransferCommandBase.get_sodar_info",
+        my_get_sodar_info,
+    )
 
     fake_os = fake_filesystem.FakeOsModule(fs)
     mocker.patch("glob.os", fake_os)
@@ -147,6 +109,7 @@ def test_run_snappy_itransfer_variant_calling_smoke_test(
 
     fake_open = fake_filesystem.FakeFileOpen(fs)
     mocker.patch("cubi_tk.snappy.itransfer_common.open", fake_open)
+    mocker.patch("cubi_tk.snappy.common.open", fake_open)
 
     mock_check_call = mock.mock_open()
     mocker.patch("cubi_tk.snappy.itransfer_common.check_call", mock_check_call)

--- a/tests/test_snappy_varfish_upload.py
+++ b/tests/test_snappy_varfish_upload.py
@@ -1,32 +1,14 @@
 """Tests for ``cubi_tk.snappy.varfish_upload``."""
 import pathlib
 
-from biomedsheets import models, shortcuts
 from biomedsheets.io_tsv import read_germline_tsv_sheet
 from biomedsheets.naming import NAMING_ONLY_SECONDARY_ID
 
-
-from cubi_tk.snappy.varfish_upload import load_sheet_tsv, yield_ngs_library_names
-
-
-def test_load_sheet_tsv():
-    """Tests varfish_upload.load_sheet_tsv()"""
-    # Define expected
-    expected_ngs_library_name_list = ["P001-N1-DNA1-WGS1", "P004-N1-DNA1-WGS1", "P007-N1-DNA1-WGS1"]
-
-    # Define input
-    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet.tsv"
-    # Get actual
-    sheet = load_sheet_tsv(path_tsv=sheet_path)
-    assert isinstance(sheet, models.Sheet)
-    # Convert to manageable format
-    shortcut_sheet = shortcuts.GermlineCaseSheet(sheet)
-    for pedigree in shortcut_sheet.cohort.pedigrees:
-        assert pedigree.index.dna_ngs_library.name in expected_ngs_library_name_list
+from cubi_tk.snappy.varfish_upload import yield_ngs_library_names
 
 
 def test_yield_ngs_library_names():
-    """Tests varfish_upload.yield_ngs_library_names()"""
+    """Tests yield_ngs_library_names()"""
     # Define expected
     expected_batch_one = ["P001-N1-DNA1-WGS1"]
     expected_batch_two = ["P004-N1-DNA1-WGS1"]


### PR DESCRIPTION
closes #51 

**Changes**
All changes involve commands: `cubi-tk snappy itransfer-*`
* New flag `--last-batch`, last batch number to be transferred.
* Flag `start-batch` renamed for consistency , now `--first-batch`.
* Argument `biomedsheet_tsv` removed. Now getting sample sheet path based on config file, i.e., `.snappy_pipeline/config.yaml`.
* Removed possibility to accept iRODS path as destination. Now code only accepts landing zone or project UUIDs - path defined using API.

**Test**
Tested using internal cohort 'PID' (last available batch:14) without transferring variant calling files from the landing zone. Same result: 392 files (1.2 Gb).
Commands:
```
# Old way
cubi-tk snappy itransfer-variant-calling --start-batch 13  .snappy_pipeline/<PID>.tsv  <PID_UUID>
# New way
cubi-tk snappy itransfer-variant-calling --first-batch 13 --last-batch 14  <PID_UUID>
```