### PR TITLE
Update sodar-cli api call for sodar download-sheet

### DIFF
--- a/cubi_tk/sodar/download_sheet.py
+++ b/cubi_tk/sodar/download_sheet.py
@@ -125,7 +125,7 @@ class DownloadSheetCommand:
         if not out_path.exists() and self.config.makedirs:
             out_path.mkdir(parents=True)
 
-        isa_dict = api.samplesheet.retrieve(
+        isa_dict = api.samplesheet.export(
             sodar_url=self.config.sodar_url,
             sodar_api_token=self.config.sodar_api_token,
             project_uuid=self.config.project_uuid,


### PR DESCRIPTION
closes #52 

**Changes**
* Update `sodar-cli` API call for `cubi-tk sodar download-sheet`

**Test**
* Tested with internal SODAR project ''seasnap test data'': `cubi-tk sodar download-sheet <PROJECT_UUID> isatab`
Output:
```
isatab/
|-- a_monocytes.txt
|-- i_Investigation.txt
`-- s_monocytes.txt
```