### PR TITLE
Reimplement irods check using python client (#59)

### DIFF
--- a/cubi_tk/irods/__init__.py
+++ b/cubi_tk/irods/__init__.py
@@ -1,10 +1,10 @@
-"""``cubi-tk irods``: iRods command line interface.
+"""``cubi-tk irods``: iRODS command line interface.
 
 Sub Commands
 ------------
 
 ``check``
-    Check target iRods collection (all md5 files? metadata md5 consistent? enough replicas?).
+    Check target iRODS collection (all md5 files? metadata md5 consistent? enough replicas?).
 
 More Information
 ----------------
@@ -26,13 +26,13 @@ def setup_argparse(parser: argparse.ArgumentParser) -> None:
     setup_argparse_check(
         subparsers.add_parser(
             "check",
-            help="Check target iRods collection (all md5 files? metadata md5 consistent? enough replicas?).",
+            help="Check target iRODS collection (all MD5 files? metadata MD5 consistent? enough replicas?).",
         )
     )
 
 
 def run(args, parser, subparser):
-    """Main entry point for irods command."""
+    """Main entry point for iRODS command."""
     if not args.irods_cmd:  # pragma: nocover
         return run_nocmd(args, parser, subparser)
     else:

--- a/cubi_tk/irods/check.py
+++ b/cubi_tk/irods/check.py
@@ -1,31 +1,51 @@
-"""``cubi-tk irods check``: Check target iRods collection (all md5 files? metadata md5 consistent? enough replicas?)."""
+"""``cubi-tk irods check``: Check target iRODS collection (all md5 files? metadata md5 consistent? enough replicas?)."""
 
-import os
-import sys
 import argparse
+import getpass
+import json
+import os
+import random
 import re
-import typing
-import uuid
-from multiprocessing.pool import ThreadPool
-from subprocess import check_output, SubprocessError
-from retrying import retry
-
-from logzero import logger
+import string
+import sys
 import tqdm
+import typing
 
+from irods.exception import CAT_NO_ROWS_FOUND
+from irods.models import Collection, DataObject
+from irods.query import SpecificQuery
+from irods.session import iRODSSession
+from logzero import logger
+from multiprocessing.pool import ThreadPool
 
 MIN_NUM_REPLICAS = 2
-NUM_PARALLEL_TESTS = 8
+NUM_PARALLEL_TESTS = 4
+MD5_RE = re.compile(r"[0-9a-fA-F]{32}")
 
 
 class IrodsCheckCommand:
-    """Implementation of irods check command."""
+    """Implementation of iRDOS check command."""
 
     command_name = "check"
 
     def __init__(self, args):
         #: Command line arguments.
         self.args = args
+
+        #: iRODS sessions for parallel execution
+        self.irods_sessions = []
+
+        #: iRODS environment
+        self.irods_env = None
+
+        #: iRODS password
+        self.irods_pass = None
+
+    def __del__(self):
+        # Ensure cleanup of iRODS sessions
+        # NOTE: Possibly not necessary anymore with python-irodsclient v1.0.0?
+        for irods in self.irods_sessions:
+            irods.cleanup()
 
     @classmethod
     def setup_argparse(cls, parser: argparse.ArgumentParser) -> None:
@@ -34,40 +54,79 @@ class IrodsCheckCommand:
         )
 
         parser.add_argument(
+            "-r",
             "--num-replicas",
+            dest="req_num_reps",
             type=int,
             default=MIN_NUM_REPLICAS,
             help="Minimum number of replicas, defaults to %s" % MIN_NUM_REPLICAS,
         )
 
         parser.add_argument(
+            "-n",
             "--num-parallel-tests",
             type=int,
             default=NUM_PARALLEL_TESTS,
             help="Number of parallel tests, defaults to %s" % NUM_PARALLEL_TESTS,
         )
 
-        parser.add_argument("irods_path", help="Path to an iRods collection.")
+        parser.add_argument("irods_path", help="Path to an iRODS collection.")
 
-    def get_files(self):
-        """get files on iRods."""
+    @classmethod
+    def get_irods_error(cls, e: Exception):
+        """Return logger friendly iRODS exception."""
+        es = str(e)
+        return es if es != "None" else e.__class__.__name__
+
+    def get_irods_env(self):
+        """Load iRODS environment from JSON file."""
+        irods_env_path = os.path.join(os.path.expanduser("~"), ".irods", "irods_environment.json")
         try:
-            ils_out = check_output(["ils", "-r", self.args.irods_path]).decode(sys.stdout.encoding)
-        except SubprocessError as e:  # pragma: nocover
-            logger.error("Something went wrong: %s\nAre you logged in? try 'iinit'", e)
+            with open(irods_env_path, "r") as f:
+                self.irods_env = json.load(f)
+        except Exception as e:
+            logger.error("Failed to read ~/.irods/irods_environment.json: %s", e)
             raise
-        files = dict(files=[], md5=[])
-        base_path = None
-        for line in ils_out.split("\n"):
-            m = re.fullmatch(r"(\s+)?(C-\s)?(\S+)\s*", line)
-            if m:
-                g = m.groups()
-                if not g[0]:
-                    base_path = g[2][:-1]
-                elif not g[1]:
-                    ftype = "files" if g[2][-4:] != ".md5" else "md5"
-                    files[ftype].append(os.path.join(base_path, g[2]))
-        return files
+
+    def connect(self):
+        """Connect to iRODS."""
+        try:
+            return iRODSSession(password=self.irods_pass, **self.irods_env)
+        except Exception as e:
+            logger.error("iRODS connection failed: %s", self.get_irods_error(e))
+            raise
+
+    def get_file_paths(self, irods: iRODSSession):
+        """Get data objects recursively under the given iRODS path."""
+        # NOTE: We don't use walk() as it is extremely slow and inefficient
+        sql = (
+            "SELECT DISTINCT ON (data_id) data_name, coll_name "
+            "FROM r_data_main JOIN r_coll_main USING (coll_id) "
+            "WHERE (coll_name = '{coll_path}' "
+            "OR coll_name LIKE '{coll_path}/%')".format(coll_path=self.args.irods_path)
+        )
+        columns = [DataObject.name, Collection.name]
+        query_alias = "cubi-tk_query_" + "".join(
+            random.SystemRandom().choice(string.ascii_lowercase) for _ in range(16)
+        )
+        query = SpecificQuery(irods, sql, query_alias, columns)
+        query.register()
+        file_paths = dict(files=[], md5s=[])
+
+        try:
+            results = query.get_results()
+            for row in results:
+                path = row[Collection.name] + "/" + row[DataObject.name]
+                k = "md5s" if path.endswith(".md5") else "files"
+                file_paths[k].append(path)
+        except CAT_NO_ROWS_FOUND:
+            logger.info("No data objects found in iRODS path")
+        except Exception as e:
+            logger.error("Data object query failed: %s", self.get_irods_error(e))
+        finally:
+            query.remove()
+
+        return file_paths
 
     def check_args(self, _args):
         return None
@@ -84,87 +143,107 @@ class IrodsCheckCommand:
         res = self.check_args(self.args)
         if res:  # pragma: nocover
             return res
-
         logger.info("Starting cubi-tk irods %s", self.command_name)
-        logger.info("  args: %s", self.args)
+        logger.info("Args: %s", self.args)
 
-        self.run_tests(self.get_files())
+        # Get iRODS environment and user password
+        self.get_irods_env()
+        logger.info("iRODS environment: %s", self.irods_env)
+        user_name = self.irods_env.get("irods_user_name")
+        self.irods_pass = getpass.getpass(f"Password for user {user_name}: ", stream=sys.stderr)
 
+        # Test connection
+        irods = self.connect()
+        try:
+            irods.collections.get(self.args.irods_path)
+            logger.info("iRODS connection initialized")
+        except Exception as e:
+            logger.error("Failed to retrieve iRODS path: %s", self.get_irods_error(e))
+            raise
+
+        # Get files and run checks
+        self.run_checks(irods, self.get_file_paths(irods))
         logger.info("All done")
-        return None
 
-    def run_tests(self, files):
-        """Run tests in parallel."""
-        num_files = len(files["files"])
-        lst_files = "\n".join(files["files"][:19])
-        logger.info("Checking %s files (first 20 shown):\n%s", num_files, lst_files)
+    def run_checks(self, irods: iRODSSession, file_paths: dict):
+        """Run checks on files, in parallel if enabled."""
+        num_files = len(file_paths["files"])
+        lst_files = "\n".join(file_paths["files"][:19])
+        logger.info(
+            "Checking %s file%s%s:\n%s",
+            num_files,
+            "s" if num_files != 1 else "",
+            " (first 20 shown)" if num_files > 20 else "",
+            lst_files,
+        )
 
         # counter = Value(c_ulonglong, 0)
         with tqdm.tqdm(total=num_files, unit="files", unit_scale=False) as t:
-            if self.args.num_parallel_tests == 0:
-                for file in files["files"]:
-                    check_file(file, files["md5"], self.args.num_replicas, t)
-            else:
-                pool = ThreadPool(processes=self.args.num_parallel_tests)
-                for file in files["files"]:
-                    pool.apply_async(
-                        check_file, args=(file, files["md5"], self.args.num_replicas, t)
+            self.irods_sessions = [irods]
+
+            if self.args.num_parallel_tests < 2:
+                for path in file_paths["files"]:
+                    check_file(
+                        self.irods_sessions[0], path, file_paths["md5s"], self.args.req_num_reps, t
                     )
-                pool.close()
-                pool.join()
+                return
+
+            if num_files < self.args.num_parallel_tests:
+                s_count = num_files
+            else:
+                s_count = self.args.num_parallel_tests
+            self.irods_sessions += [self.connect() for _ in range(s_count - 1)]
+            pool = ThreadPool(processes=self.args.num_parallel_tests)
+            s_idx = 0
+            for path in file_paths["files"]:
+                pool.apply_async(
+                    check_file,
+                    args=(
+                        self.irods_sessions[s_idx],
+                        path,
+                        file_paths["md5s"],
+                        self.args.req_num_reps,
+                        t,
+                    ),
+                )
+                if s_idx == self.args.num_parallel_tests - 1:
+                    s_idx = 0
+                else:
+                    s_idx += 1
+            pool.close()
+            pool.join()
 
 
-@retry(wait_fixed=1000, stop_max_attempt_number=3)
-def check_file(file, md5s, req_num_reps, t):
+def check_file(irods: iRODSSession, path: str, md5s: list, req_num_reps: int, t):
     """Perform checks for a single file."""
+    data_obj = irods.data_objects.get(path)
 
     # 1) md5 sum file exists?
-    if file + ".md5" not in md5s:
-        e_msg = f"No md5 sum file for: {file}"
+    if path + ".md5" not in md5s:
+        e_msg = f"No md5 sum file for: {path}"
         logger.error(e_msg)
-        # raise FileNotFoundError(e_msg)
 
     # 2) enough replicas?
-    try:
-        isysmeta_out = check_output(["isysmeta", "-l", "ls", "{file}"]).decode(sys.stdout.encoding)
-    except SubprocessError as e:  # pragma: nocover
-        logger.error("Problem executing isysmeta: %s (probably retrying)", e)
-        raise
-    meta_info = [
-        {
-            lst[0]: lst[1:]
-            for lst in (entry.split(": ") for entry in repl.splitlines())
-            if len(lst) > 0
-        }
-        for repl in isysmeta_out.split("----")
-    ]
-    if len(meta_info) < req_num_reps:
-        e_msg = f"Not enough ({req_num_reps}) replicates for file: {file}"
-        logger.error(e_msg)
-        # raise FileNotFoundError(e_msg)
-
-    # 3) checksum consistent with .md5 file?
-    try:
-        temp_file = f"./temp_{str(uuid.uuid4())}.md5"
-        check_output(["irsync", "-aK", "i:{file}.md5", temp_file])
-    except SubprocessError as e:  # pragma: nocover
-        logger.error("Could not fetch file for md5 sum check: %s.md5: %s", temp_file, e)
-        raise
-
-    with open(temp_file, "r") as f:
-        md5sum = re.match(r"\S+", f.read()).group(0)
-    os.remove(temp_file)
-
-    if not all(repl["data_checksum"][0] == md5sum for repl in meta_info):
-        logger.error(
-            "File checksum not consistent with md5 file...\n"
-            "file: %s\n.md5-file checksum: %s\n"
-            "metadata checksum: %s",
-            file,
-            md5sum,
-            meta_info[0]["data_checksum"],
+    if len(data_obj.replicas) < req_num_reps:
+        e_msg = (
+            f"Not enough replicas ({len(data_obj.replicas)} < " f"{req_num_reps}) for file: {path}"
         )
-        # raise ValueError(e_msg)
+        logger.error(e_msg)
+
+    # 3) checksums of all replicas consistent with .md5 file?
+    md5_obj = irods.data_objects.open(path + ".md5", mode="r")
+    file_sum = re.search(MD5_RE, md5_obj.read().decode("utf-8")).group(0)
+    for replica in data_obj.replicas:
+        if replica.checksum != file_sum:
+            logger.error(
+                "iRODS metadata checksum not consistent with MD5 file...\n"
+                "File: %s\nMD5 file checksum: %s\n"
+                "Metadata checksum: %s\nResource: %s",
+                path,
+                file_sum,
+                replica.checksum,
+                replica.resource_name,
+            )
 
     # with counter.get_lock():
     #    counter.value += 1

--- a/cubi_tk/irods/check.py
+++ b/cubi_tk/irods/check.py
@@ -206,10 +206,6 @@ class IrodsCheckCommand:
                     )
                 return
 
-            if num_files < self.args.num_parallel_tests:
-                s_count = num_files
-            else:
-                s_count = self.args.num_parallel_tests
             pool = ThreadPool(processes=self.args.num_parallel_tests)
             s_idx = 0
             for obj in data_objs["files"]:

--- a/cubi_tk/irods/check.py
+++ b/cubi_tk/irods/check.py
@@ -48,6 +48,8 @@ class IrodsCheckCommand:
 
     @contextmanager
     def _get_irods_sessions(self, count=NUM_PARALLEL_TESTS):
+        if count < 1:
+            count = 1
         irods_sessions = [self._init_irods() for _ in range(count)]
         try:
             yield irods_sessions

--- a/cubi_tk/irods/check.py
+++ b/cubi_tk/irods/check.py
@@ -59,7 +59,7 @@ class IrodsCheckCommand:
         )
 
         parser.add_argument(
-            "-n",
+            "-p",
             "--num-parallel-tests",
             type=int,
             default=NUM_PARALLEL_TESTS,

--- a/cubi_tk/irods/check.py
+++ b/cubi_tk/irods/check.py
@@ -66,7 +66,6 @@ class IrodsCheckCommand:
         parser.add_argument(
             "--hidden-cmd", dest="irods_cmd", default=cls.run, help=argparse.SUPPRESS
         )
-
         parser.add_argument(
             "-r",
             "--num-replicas",
@@ -75,7 +74,6 @@ class IrodsCheckCommand:
             default=MIN_NUM_REPLICAS,
             help="Minimum number of replicas, defaults to %s" % MIN_NUM_REPLICAS,
         )
-
         parser.add_argument(
             "-p",
             "--num-parallel-tests",
@@ -83,7 +81,6 @@ class IrodsCheckCommand:
             default=NUM_PARALLEL_TESTS,
             help="Number of parallel tests, defaults to %s" % NUM_PARALLEL_TESTS,
         )
-
         parser.add_argument(
             "-d",
             "--num-display-files",
@@ -91,7 +88,6 @@ class IrodsCheckCommand:
             default=NUM_DISPLAY_FILES,
             help="Number of files listed when checking, defaults to %s" % NUM_DISPLAY_FILES,
         )
-
         parser.add_argument(
             "-s",
             "--hash-scheme",
@@ -99,7 +95,6 @@ class IrodsCheckCommand:
             default=DEFAULT_HASH_SCHEME,
             help="Hash scheme used to verify checksums, defaults to %s" % DEFAULT_HASH_SCHEME,
         )
-
         parser.add_argument("irods_path", help="Path to an iRODS collection.")
 
     @classmethod
@@ -111,9 +106,7 @@ class IrodsCheckCommand:
     def get_data_objs(self, root_coll: iRODSCollection):
         """Get data objects recursively under the given iRODS path."""
         data_objs = dict(files=[], checksums={})
-        ignore_schemes = [
-            k.lower() for k in HASH_SCHEMES.keys() if k != self.args.hash_scheme.upper()
-        ]
+        ignore_schemes = [k.lower() for k in HASH_SCHEMES if k != self.args.hash_scheme.upper()]
         for res in root_coll.walk():
             for obj in res[2]:
                 if obj.path.endswith("." + self.args.hash_scheme.lower()):
@@ -124,7 +117,7 @@ class IrodsCheckCommand:
 
     def check_args(self, _args):
         # Check hash scheme
-        if _args.hash_scheme.upper() not in HASH_SCHEMES.keys():
+        if _args.hash_scheme.upper() not in HASH_SCHEMES:
             logger.error(
                 'Invalid hash scheme "{}"; accepted values: {}'.format(
                     _args.hash_scheme.upper(), ", ".join(HASH_SCHEMES.keys())
@@ -153,7 +146,7 @@ class IrodsCheckCommand:
         logger.info("Args: %s", self.args)
 
         # Load iRODS environment
-        with open(self.irods_env_path, "r") as f:
+        with open(self.irods_env_path, "r", encoding="utf-8") as f:
             irods_env = json.load(f)
         logger.info("iRODS environment: %s", irods_env)
 
@@ -173,10 +166,10 @@ class IrodsCheckCommand:
             # Get files and run checks
             logger.info("Querying for data objects")
             data_objs = self.get_data_objs(root_coll)
-            self.run_checks(irods_sessions, data_objs)
+            self.run_checks(data_objs)
             logger.info("All done")
 
-    def run_checks(self, irods_sessions: list, data_objs: dict):
+    def run_checks(self, data_objs: dict):
         """Run checks on files, in parallel if enabled."""
         num_files = len(data_objs["files"])
         dsp_files = data_objs["files"]
@@ -263,8 +256,6 @@ def check_file(data_obj: iRODSDataObject, checksums: dict, req_num_reps: int, ha
         )
         logger.error(e_msg)
 
-    # with counter.get_lock():
-    #    counter.value += 1
     t.update()
 
 

--- a/cubi_tk/sea_snap/check_irods.py
+++ b/cubi_tk/sea_snap/check_irods.py
@@ -77,7 +77,7 @@ class SeasnapCheckIrodsCommand(IrodsCheckCommand):
 
         # --- get lists
         # files on SODAR
-        files = self.get_file_paths()
+        files = self.get_data_objs()
         files_rel = [f.replace(self.args.irods_path + "/", "") for f in files["files"]]
         logger.info("Files on SODAR (first 20): %s", ", ".join(files_rel[:19]))
 

--- a/cubi_tk/sea_snap/check_irods.py
+++ b/cubi_tk/sea_snap/check_irods.py
@@ -77,7 +77,7 @@ class SeasnapCheckIrodsCommand(IrodsCheckCommand):
 
         # --- get lists
         # files on SODAR
-        files = self.get_files()
+        files = self.get_file_paths()
         files_rel = [f.replace(self.args.irods_path + "/", "") for f in files["files"]]
         logger.info("Files on SODAR (first 20): %s", ", ".join(files_rel[:19]))
 
@@ -117,7 +117,7 @@ class SeasnapCheckIrodsCommand(IrodsCheckCommand):
                 return None
 
         # generic tests (md5 sums, metadata, #replicas)
-        self.run_tests(files)
+        self.run_checks(files)
 
         logger.info("All done")
         return res

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,4 +65,5 @@ simplejson
 sodar-cli ==0.1.0
 
 # Python iRODS client
-python-irodsclient>=1.0.0, <1.1
+# python-irodsclient>=1.0.0, <1.1
+-e git+https://github.com/irods/python-irodsclient.git@e00523bcc159d4e55a7d1920a0bb8e345bf38796#egg=python-irodsclient

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,3 +63,6 @@ simplejson
 
 # REST API client for SODAR
 sodar-cli ==0.1.0
+
+# Python iRODS client
+python-irodsclient>=1.0.0, <1.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,5 +65,4 @@ simplejson
 sodar-cli ==0.1.0
 
 # Python iRODS client
-# python-irodsclient>=1.0.0, <1.1
--e git+https://github.com/irods/python-irodsclient.git@e00523bcc159d4e55a7d1920a0bb8e345bf38796#egg=python-irodsclient
+python-irodsclient==1.1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ exclude =
     .github
     .tox
     docs/
+    src/
     cubi_tk/__init__.py
     versioneer.py
 


### PR DESCRIPTION
Here's my solution for re-implementing the iRODS check using python-irodsclient instead of shell hacks.

Some notes:

- For opening a session via the client we require the user's iRODS password. My solution was to prompt for this in CLI as storing passwords as clear text is a no-no. I'm open for better ideas.
- Based on my own testing (which includes running this on an iRODS collection with 2500*2 files) opening several sessions and running in parallel does not seem to speed up the checks much at all. We might want to ditch the parallel stuff altogether to simplify the code, but that's your call.
- The alternate version of irods check under sea-snap does not work with the initial commit. If you give thumbs up to this one I should be quite easily able to refactor the hard coded parts to work similarly.
- Codacy doesn't like us providing raw SQL to `SpecificQuery()`. That's too bad, but not much I can do. It's the only efficient way to get file listings recursively. `walk()` is horribly inefficient and becomes unusable beyond a couple of subcollections. Been there, tried that.
- If I have accidentally broken some cubi-tk conventions, please let me know :P