### PR TITLE
Adjusted CI to install hashdeep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ jobs:
           lfs: true
       - name: Install mamba.
         run: conda install -y mamba
+      - name: Prepare environment.yaml file.
+        run: >
+          cp environment.yaml /tmp/environment.yaml && sed -i -e
+          's/- python/- python=${{ matrix.python-version }}/'
+          /tmp/environment.yaml
+      - name: Update environment using mamba.
+        run: mamba env update --name root --file /tmp/environment.yaml
       - name: Save time by installing packages via mamba
         run: mamba install -y pysam
       - name: Install test dependencies via pip

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,6 @@
+name: cubi-tk
+
+dependencies:
+  - python
+  - pip
+  - hashdeep


### PR DESCRIPTION
addresses #67 

**Changes**
Included new environment file to be used for `hashdeep` installation.

**Note:** Assertion error remained in test `test_run_archive_copy_smoke_test`.