### PR TITLE
Add generic itransfer-step

### DIFF
--- a/cubi_tk/snappy/__init__.py
+++ b/cubi_tk/snappy/__init__.py
@@ -11,6 +11,8 @@ Available Commands
     Transfer results and logs from ``output`` directory of ``ngs_mapping``.
 ``itransfer-variant-calling``
     Transfer results and logs from ``output`` directory of ``variant_calling``.
+``itransfer-step``
+    Transfer results and logs from ``output`` directory of any snappy pipeline step.
 ``pull-sheet``
     Pull sample sheet from SODAR and write out to BiomedSheet format.
 ``pull-raw-data``
@@ -34,6 +36,7 @@ from .check import setup_argparse as setup_argparse_check
 from .itransfer_raw_data import setup_argparse as setup_argparse_itransfer_raw_data
 from .itransfer_ngs_mapping import setup_argparse as setup_argparse_itransfer_ngs_mapping
 from .itransfer_variant_calling import setup_argparse as setup_argparse_itransfer_variant_calling
+from .itransfer_step import setup_argparse as setup_argparse_itransfer_step
 from .pull_sheets import setup_argparse as setup_argparse_pull_sheets
 from .pull_raw_data import setup_argparse as setup_argparse_pull_raw_data
 from .kickoff import setup_argparse as setup_argparse_kickoff
@@ -62,6 +65,11 @@ def setup_argparse(parser: argparse.ArgumentParser) -> None:
         subparsers.add_parser(
             "itransfer-variant-calling",
             help="Transfer variant_calling results into iRODS landing zone",
+        )
+    )
+    setup_argparse_itransfer_step(
+        subparsers.add_parser(
+            "itransfer-step", help="Transfer snappy step results into iRODS landing zone"
         )
     )
 

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -650,13 +650,6 @@ class SnappyItransferCommandBase:
         logger.info("Starting cubi-tk snappy %s", self.command_name)
         logger.info("  args: %s", self.args)
 
-        # The test below should not be done here, but in check_args.
-        # However, it makes cubi_tk.sodar.ingest_fastq fail, as it
-        # sub-classes SnappyItransferCommandBase, without overriding
-        # check_args.
-        if self.step_name is None and self.args.step is None:
-            logger.error("Snappy step is not defined")
-            return 1
         # Fix for ngs_mapping & variant_calling vs step
         if self.step_name is None:
             self.step_name = self.args.step

--- a/cubi_tk/snappy/itransfer_step.py
+++ b/cubi_tk/snappy/itransfer_step.py
@@ -1,0 +1,42 @@
+"""``cubi-tk snappy itransfer-step``: transfer step results into iRODS landing zone."""
+
+import argparse
+import os
+import typing
+
+from logzero import logger
+
+from .itransfer_common import SnappyItransferCommandBase
+
+
+class SnappyItransferStepCommand(SnappyItransferCommandBase):
+    """Implementation of snappy itransfer command for results from any step."""
+
+    fix_md5_files = True
+    command_name = "itransfer-step"
+    step_name = None
+
+    @classmethod
+    def setup_argparse(cls, parser: argparse.ArgumentParser) -> None:
+        super().setup_argparse(parser)
+        parser.add_argument(
+            "--step", help="Name of the snappy pipeline step", default="ngs_mapping"
+        )
+        parser.add_argument(
+            "--tool", help="Name of the tool, for example bwa. Tools order in important", nargs="*"
+        )
+
+    def build_base_dir_glob_pattern(self, library_name: str) -> typing.Tuple[str, str]:
+        prefix = ".".join(self.args.tool)
+        logger.debug("Using prefix {}".format(prefix))
+        return (
+            os.path.join(
+                self.args.base_path, self.step_name, "output", prefix + "." + library_name
+            ),
+            "**",
+        )
+
+
+def setup_argparse(parser: argparse.ArgumentParser) -> None:
+    """Setup argument parser for ``cubi-tk snappy itransfer-step``."""
+    return SnappyItransferStepCommand.setup_argparse(parser)

--- a/cubi_tk/snappy/itransfer_step.py
+++ b/cubi_tk/snappy/itransfer_step.py
@@ -20,10 +20,25 @@ class SnappyItransferStepCommand(SnappyItransferCommandBase):
     def setup_argparse(cls, parser: argparse.ArgumentParser) -> None:
         super().setup_argparse(parser)
         parser.add_argument(
-            "--step", help="Name of the snappy pipeline step", default="ngs_mapping"
+            "--step",
+            help=(
+                "Name of the snappy pipeline step (step name must be identical to step directory)."
+                "Steps names are available from the snappy command snappy-start-step --help"
+            ),
+            default=None,
         )
         parser.add_argument(
-            "--tool", help="Name of the tool, for example bwa. Tools order in important", nargs="*"
+            "--tool",
+            help=(
+                "Name of the tool, for example bwa. Tools order in important:"
+                "it must match the order used to generate filename prefix."
+                "For example, the variant annotation step requires the mapper, caller and"
+                "the annotator software. In that case, the snappy file prefix is:"
+                "<mapper>.<caller>.<annotator>, so the command would be:"
+                "--tool <mapper> <vcaller> <annotator>. Some steps add more information to their"
+                "prefix, for example 'jannovar_somatic_vcf'"
+            ),
+            nargs="*",
         )
 
     def build_base_dir_glob_pattern(self, library_name: str) -> typing.Tuple[str, str]:
@@ -35,6 +50,16 @@ class SnappyItransferStepCommand(SnappyItransferCommandBase):
             ),
             "**",
         )
+
+    def check_args(self, args):
+        """Called for checking arguments, override to change behaviour."""
+        res = super().check_args(args)
+
+        if self.step_name is None and self.args.step is None:
+            logger.error("Snappy step is not defined")
+            return 1
+
+        return res
 
 
 def setup_argparse(parser: argparse.ArgumentParser) -> None:

--- a/tests/test_snappy_itransfer_step.py
+++ b/tests/test_snappy_itransfer_step.py
@@ -26,6 +26,16 @@ def test_run_snappy_itransfer_ngs_mapping_help(capsys):
     assert not res.err
 
 
+def test_run_snappy_itransfer_ngs_mapping_nostep(capsys):
+    sodar_uuid = "466ab946-ce6a-4c78-9981-19b79e7bbe86"
+    argv = ["snappy", "itransfer-step", "--sodar-api-token", "XXXX", sodar_uuid, "--tool", "bwa"]
+
+    parser, subparsers = setup_argparse()
+
+    res = main(argv)
+    assert res == 1
+
+
 def test_run_snappy_itransfer_ngs_mapping_nothing(capsys):
     parser, subparsers = setup_argparse()
 
@@ -115,14 +125,6 @@ def test_run_snappy_itransfer_ngs_mapping_smoke_test(
 
     mock_check_call = mock.mock_open()
     mocker.patch("cubi_tk.snappy.itransfer_common.check_call", mock_check_call)
-
-    # # requests mock
-    # return_value = dict(assay="", config_data="", configuration="", date_modified="", description="", irods_path=sodar_path, project="", sodar_uuid="", status="", status_info="", title="", user="")
-    # url_tpl = "%(sodar_url)s/landingzones/api/retrieve/%(landing_zone_uuid)s"
-    # url = url_tpl % {"sodar_url": args.sodar_url, "landing_zone_uuid": args.landing_zone_uuid}
-    # requests_mock.get(url, text=json.dumps(return_value))
-    # #requests_mock.get("resource://biomedsheets//data/std_fields.json", text="dummy")
-    # #requests_mock.get("resource://biomedsheets/data/std_fields.json#/extraInfoDefs/template/ncbiTaxon", text="dummy")
 
     # Actually exercise code and perform test.
     res = main(argv)

--- a/tests/test_snappy_itransfer_step.py
+++ b/tests/test_snappy_itransfer_step.py
@@ -1,0 +1,156 @@
+"""Tests for ``cubi_tk.snappy.itransfer_step``.
+
+We only run some smoke tests here.
+"""
+
+import os
+from unittest import mock
+from unittest.mock import ANY
+
+import pytest
+from pyfakefs import fake_filesystem
+
+from .conftest import my_exists, my_get_sodar_info
+from cubi_tk.__main__ import setup_argparse, main
+
+
+def test_run_snappy_itransfer_ngs_mapping_help(capsys):
+    parser, subparsers = setup_argparse()
+    with pytest.raises(SystemExit) as e:
+        parser.parse_args(["snappy", "itransfer-step", "--help"])
+
+    assert e.value.code == 0
+
+    res = capsys.readouterr()
+    assert res.out
+    assert not res.err
+
+
+def test_run_snappy_itransfer_ngs_mapping_nothing(capsys):
+    parser, subparsers = setup_argparse()
+
+    with pytest.raises(SystemExit) as e:
+        parser.parse_args(["snappy", "itransfer-step"])
+
+    assert e.value.code == 2
+
+    res = capsys.readouterr()
+    assert not res.out
+    assert res.err
+
+
+def test_run_snappy_itransfer_ngs_mapping_smoke_test(
+    mocker, germline_trio_sheet_tsv, minimal_config
+):
+    fake_base_path = "/base/path"
+    dest_path = "/irods/dest"
+    sodar_uuid = "466ab946-ce6a-4c78-9981-19b79e7bbe86"
+    argv = [
+        "--verbose",
+        "snappy",
+        "itransfer-step",
+        "--step",
+        "ngs_mapping",
+        "--base-path",
+        fake_base_path,
+        "--sodar-api-token",
+        "XXXX",
+        sodar_uuid,
+        "--tool",
+        "bwa",
+    ]
+
+    parser, subparsers = setup_argparse()
+    args = parser.parse_args(argv)
+
+    # Setup fake file system but only patch selected modules.  We cannot use the Patcher approach here as this would
+    # break both biomedsheets and multiprocessing.
+    fs = fake_filesystem.FakeFilesystem()
+
+    fake_file_paths = []
+    for member in ("index", "father", "mother"):
+        for ext in ("", ".md5"):
+            fake_file_paths.append(
+                "%s/ngs_mapping/output/bwa.%s-N1-DNA1-WES1/out/%s-N1-DNA1-WES1.bam%s"
+                % (fake_base_path, member, member, ext)
+            )
+            fs.create_file(fake_file_paths[-1])
+            fake_file_paths.append(
+                "%s/ngs_mapping/output/bwa.%s-N1-DNA1-WES1/log/bwa.%s-N1-DNA1-WES1.log%s"
+                % (fake_base_path, member, member, ext)
+            )
+            fs.create_file(fake_file_paths[-1])
+
+    # Create sample sheet in fake file system
+    sample_sheet_path = fake_base_path + "/.snappy_pipeline/sheet.tsv"
+    fs.create_file(sample_sheet_path, contents=germline_trio_sheet_tsv, create_missing_dirs=True)
+    # Create config in fake file system
+    config_path = fake_base_path + "/.snappy_pipeline/config.yaml"
+    fs.create_file(config_path, contents=minimal_config, create_missing_dirs=True)
+
+    # Print path to all created files
+    print("\n".join(fake_file_paths + [sample_sheet_path, config_path]))
+
+    # Remove index's log MD5 file again so it is recreated.
+    fs.remove(fake_file_paths[3])
+
+    # Set Mocker
+    mocker.patch("pathlib.Path.exists", my_exists)
+    mocker.patch(
+        "cubi_tk.snappy.itransfer_common.SnappyItransferCommandBase.get_sodar_info",
+        my_get_sodar_info,
+    )
+
+    fake_os = fake_filesystem.FakeOsModule(fs)
+    mocker.patch("glob.os", fake_os)
+    mocker.patch("cubi_tk.snappy.itransfer_common.os", fake_os)
+    mocker.patch("cubi_tk.snappy.itransfer_step.os", fake_os)
+
+    mock_check_output = mock.mock_open()
+    mocker.patch("cubi_tk.snappy.itransfer_common.check_output", mock_check_output)
+
+    fake_open = fake_filesystem.FakeFileOpen(fs)
+    mocker.patch("cubi_tk.snappy.itransfer_common.open", fake_open)
+    mocker.patch("cubi_tk.snappy.common.open", fake_open)
+
+    mock_check_call = mock.mock_open()
+    mocker.patch("cubi_tk.snappy.itransfer_common.check_call", mock_check_call)
+
+    # # requests mock
+    # return_value = dict(assay="", config_data="", configuration="", date_modified="", description="", irods_path=sodar_path, project="", sodar_uuid="", status="", status_info="", title="", user="")
+    # url_tpl = "%(sodar_url)s/landingzones/api/retrieve/%(landing_zone_uuid)s"
+    # url = url_tpl % {"sodar_url": args.sodar_url, "landing_zone_uuid": args.landing_zone_uuid}
+    # requests_mock.get(url, text=json.dumps(return_value))
+    # #requests_mock.get("resource://biomedsheets//data/std_fields.json", text="dummy")
+    # #requests_mock.get("resource://biomedsheets/data/std_fields.json#/extraInfoDefs/template/ncbiTaxon", text="dummy")
+
+    # Actually exercise code and perform test.
+    res = main(argv)
+
+    assert not res
+
+    # We do not care about call order but simply test call count and then assert that all files are there which would
+    # be equivalent of comparing sets of files.
+
+    assert fs.exists(fake_file_paths[3])
+
+    assert mock_check_call.call_count == 1
+    mock_check_call.assert_called_once_with(
+        ["md5sum", "bwa.index-N1-DNA1-WES1.log"],
+        cwd=os.path.dirname(fake_file_paths[3]),
+        stdout=ANY,
+    )
+
+    assert mock_check_output.call_count == len(fake_file_paths) * 3
+    for path in fake_file_paths:
+        mapper_index, rel_path = os.path.relpath(
+            path, os.path.join(fake_base_path, "ngs_mapping/output")
+        ).split("/", 1)
+        _mapper, index = mapper_index.rsplit(".", 1)
+        remote_path = os.path.join(dest_path, index, "ngs_mapping", args.remote_dir_date, rel_path)
+        expected_mkdir_argv = ["imkdir", "-p", os.path.dirname(remote_path)]
+        expected_irsync_argv = ["irsync", "-a", "-K", path, "i:%s" % remote_path]
+        expected_ils_argv = ["ils", os.path.dirname(remote_path)]
+        mock_check_output.assert_any_call(expected_mkdir_argv)
+        mock_check_output.assert_any_call(expected_irsync_argv)
+        mock_check_output.assert_any_call(expected_ils_argv, stderr=-2)


### PR DESCRIPTION
**Aim:** Generic function to add the output of any `snappy` step to SODAR.

**Remarks:**

- In the somatic/cancer branch, many steps should be added to SODAR: `somatic_variant_calling`, `somatic_variant_annotation`, `somatic_targeted_seq_cnv_calling`, `somatic_wgs_cnv_calling`, perhaps `hla_typing`, `gene_expression_quantification`, `somatic_gene_fusion_calling`, and others that will be implemented "soon".
- Supersedes `itransfer-ngs-mapping` & `itransfer-variant-calling`.
- Implementation is not ideal: missing step names are not caught in `cubi_tk.snappy.itransfer_common.check_args`, but in `cubi_tk.snappy.itransfer_common.execute`. This is because `cubi_tk.sodar.ingest_fastq` creates a sub-class of `SnappyItransferCommandBase`, without defining `step_name` and without creating a `check_args` method for the subclass. I don't think that it should, but it creates the problem described above.
- The test is copied-pasted from `test_snappy_itransfer_ngs_mapping`.
