### PR TITLE
Fix CI dependency installation error

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,8 @@
 # Base requirements
 
+# Pin version to avoid python 2 to 3 breaks
+setuptools <=57.5.0
+
 # Attrs, helpful for removing boilerplate.
 attrs
 cattrs


### PR DESCRIPTION
**Changes**
* Pinned `setuptools` version - breaking change in [58.0.0 ](https://setuptools.pypa.io/en/latest/history.html#v58-0-0)affecting dependencies.