### PR TITLE
Fix trailing spaces in tumor_normal_triplets template (#100)

### DIFF
--- a/cubi_tk/isa_tpl/isatab-tumor_normal_triplets/{{cookiecutter.i_dir_name}}/a_{{cookiecutter.assay_prefix}}_transcriptome_profiling_nucleotide_sequencing.txt
+++ b/cubi_tk/isa_tpl/isatab-tumor_normal_triplets/{{cookiecutter.i_dir_name}}/a_{{cookiecutter.assay_prefix}}_transcriptome_profiling_nucleotide_sequencing.txt
@@ -2,4 +2,4 @@ Sample Name	Protocol REF	Parameter Value[Concentration measurement]	Performer	Da
 {% set sample_names = cookiecutter.sample_names.split(",") -%}																																																			
 {%- for sample_name in sample_names -%}																																																			
 {{sample_name|replace("-", "_")}}-N1	Nucleic acid extraction RNA-Seq				{{sample_name|replace("-", "_")}}-N1-RNA1					Library construction RNA-Seq										TRANSCRIPTOMIC	RNA-Seq	PolyA	PAIRED	Illumina TruSeq Stranded mRNA	REVERSE										{{sample_name|replace("-", "_")}}-N1-RNA1-RNA-Seq1	{{sample_name}}					Nucleic acid sequencing RNA-Seq	ILLUMINA	Illumina HiSeq 4000			Phred+33					
-{% endfor %}																																																			
+{% endfor %}

--- a/cubi_tk/isa_tpl/isatab-tumor_normal_triplets/{{cookiecutter.i_dir_name}}/a_{{cookiecutter.assay_prefix}}_{{cookiecutter.assay_name}}.txt
+++ b/cubi_tk/isa_tpl/isatab-tumor_normal_triplets/{{cookiecutter.i_dir_name}}/a_{{cookiecutter.assay_prefix}}_{{cookiecutter.assay_name}}.txt
@@ -2,4 +2,4 @@ Sample Name	Protocol REF	Parameter Value[Concentration measurement]	Performer	Da
 {% set sample_names = cookiecutter.sample_names.split(",") -%}																																																		
 {%- for sample_name in sample_names -%}																																																		
 {{sample_name|replace("-", "_")}}-N1	Nucleic acid extraction {{cookiecutter.a_measurement_abbreviation}}				{{sample_name|replace("-", "_")}}-N1-DNA1					Library construction {{cookiecutter.a_measurement_abbreviation}}										GENOMIC	{{cookiecutter.lib_strategy}}	{{cookiecutter.lib_selection}}	{{cookiecutter.lib_layout}}	{{cookiecutter.lib_kits[cookiecutter.lib_kit].name}}	{{cookiecutter.lib_kits[cookiecutter.lib_kit].cat_id}}									{{sample_name|replace("-", "_")}}-N1-DNA1-{{cookiecutter.a_measurement_abbreviation}}1	{{sample_name}}					Nucleic acid sequencing {{cookiecutter.a_measurement_abbreviation}}	ILLUMINA	{{cookiecutter.instrument}}			Phred+33					
-{% endfor %}																																																		
+{% endfor %}

--- a/cubi_tk/isa_tpl/isatab-tumor_normal_triplets/{{cookiecutter.i_dir_name}}/s_{{cookiecutter.s_file_name}}.txt
+++ b/cubi_tk/isa_tpl/isatab-tumor_normal_triplets/{{cookiecutter.i_dir_name}}/s_{{cookiecutter.s_file_name}}.txt
@@ -2,4 +2,4 @@ Source Name	Characteristics[UUID]	Characteristics[External links]	Characteristic
 {% set sample_names = cookiecutter.sample_names.split(",") -%}																																																													
 {%- for sample_name in sample_names -%}																																																													
 {{sample_name|replace("-", "_")}}		{{cookiecutter.sample_type}}:{{sample_name}}		Homo sapiens	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/9606																					none										Sample collection			{{sample_name|replace("-", "_")}}-N1													Y/N	True/False							
-{% endfor %}																																																													
+{% endfor %}


### PR DESCRIPTION
Microarray was fixed, but this one still fails.