### PR TITLE
Restrict `snappy pull-raw-data` to FASTQ files

### DIFF
--- a/cubi_tk/snappy/__init__.py
+++ b/cubi_tk/snappy/__init__.py
@@ -3,8 +3,10 @@
 Available Commands
 ------------------
 
-``check``
+``check-local``
     Check consistency within sample sheet but also between sample sheet and files.
+``check-remote``
+    Check consistency between local files and files stored in SODAR.
 ``itransfer-raw-data``
     Transfer raw data from ``work/input_links`` directory of ``ngs_mapping``.
 ``itransfer-ngs-mapping``
@@ -15,8 +17,12 @@ Available Commands
     Transfer results and logs from ``output`` directory of any snappy pipeline step.
 ``pull-sheet``
     Pull sample sheet from SODAR and write out to BiomedSheet format.
+``pull-all-data``
+    Download all data from SODAR.
+``pull-processed-data``
+    Download processed data (e.g., BAM or VCF files) from SODAR.
 ``pull-raw-data``
-    Download raw data from SODAR.
+    Download raw data (i.e., FASTQ files) from SODAR.
 ``varfish-upload``
     Upload data into VarFish.
 
@@ -39,6 +45,7 @@ from .itransfer_ngs_mapping import setup_argparse as setup_argparse_itransfer_ng
 from .itransfer_variant_calling import setup_argparse as setup_argparse_itransfer_variant_calling
 from .itransfer_step import setup_argparse as setup_argparse_itransfer_step
 from .pull_sheets import setup_argparse as setup_argparse_pull_sheets
+from .pull_all_data import setup_argparse as setup_argparse_pull_all_data
 from .pull_processed_data import setup_argparse as setup_argparse_pull_processed_data
 from .pull_raw_data import setup_argparse as setup_argparse_pull_raw_data
 from .kickoff import setup_argparse as setup_argparse_kickoff
@@ -87,6 +94,12 @@ def setup_argparse(parser: argparse.ArgumentParser) -> None:
 
     setup_argparse_pull_sheets(
         subparsers.add_parser("pull-sheets", help="Pull SODAR sample sheets into biomedsheet")
+    )
+
+    setup_argparse_pull_all_data(
+        subparsers.add_parser(
+            "pull-all-data", help="Pull all data from SODAR to specified output directory"
+        )
     )
 
     setup_argparse_pull_processed_data(

--- a/cubi_tk/snappy/parse_sample_sheet.py
+++ b/cubi_tk/snappy/parse_sample_sheet.py
@@ -60,6 +60,38 @@ class ParseSampleSheet:
                     for library in test_sample.ngs_libraries.values():
                         yield library.name
 
+    def yield_ngs_library_and_folder_names(
+        self, sheet, min_batch=None, max_batch=None, batch_key="batchNo", family_key="familyId"
+    ):
+        """Yield all NGS library and folder names from sheet.
+
+        When ``min_batch`` is given then only the donors for which the ``extra_infos[batch_key]`` is greater than
+        ``min_batch`` will be used.
+
+        :param sheet: Sample sheet.
+        :type sheet: biomedsheets.models.Sheet
+
+        :param min_batch: Minimum batch number to be extracted from the sheet. All samples in batches below the
+        threshold will be skipped.
+        :type min_batch: int
+
+        :param max_batch: Maximum batch number to be extracted from the sheet. All samples in batches above the
+        threshold will be skipped.
+        :type max_batch: int
+
+        :param batch_key: Batch number key in sheet. Default: 'batchNo'.
+        :type batch_key: str
+
+        :param family_key: Family identifier key. Default: 'familyId'.
+        :type family_key: str
+        """
+        for donor in self.yield_donor(sheet, min_batch, max_batch, batch_key, family_key):
+            for bio_sample in donor.bio_samples.values():
+                for test_sample in bio_sample.test_samples.values():
+                    for library in test_sample.ngs_libraries.values():
+                        folder_name = self._get_donor_folder_name(donor) or donor.secondary_id
+                        yield library.name, folder_name
+
     def yield_sample_names(
         self, sheet, min_batch=None, max_batch=None, batch_key="batchNo", family_key="familyId"
     ):

--- a/cubi_tk/snappy/parse_sample_sheet.py
+++ b/cubi_tk/snappy/parse_sample_sheet.py
@@ -1,5 +1,4 @@
 """Common code to parse BioMedSheets"""
-from collections import OrderedDict
 from logzero import logger
 
 
@@ -61,7 +60,13 @@ class ParseSampleSheet:
                         yield library.name
 
     def yield_ngs_library_and_folder_names(
-        self, sheet, min_batch=None, max_batch=None, batch_key="batchNo", family_key="familyId"
+        self,
+        sheet,
+        min_batch=None,
+        max_batch=None,
+        batch_key="batchNo",
+        family_key="familyId",
+        selected_ids=None,
     ):
         """Yield all NGS library and folder names from sheet.
 
@@ -84,8 +89,15 @@ class ParseSampleSheet:
 
         :param family_key: Family identifier key. Default: 'familyId'.
         :type family_key: str
+
+        :param selected_ids: List of samples ids to keep, e.g., 'P001' instead of longer library name
+        'P001-N1-DNA1-WGS1'. Everything else will be ignored.
+        :type selected_ids: list
         """
         for donor in self.yield_donor(sheet, min_batch, max_batch, batch_key, family_key):
+            if selected_ids and donor.secondary_id not in selected_ids:
+                logger.debug(f"Sample '{donor.secondary_id}' not in provided selected id list.")
+                continue
             for bio_sample in donor.bio_samples.values():
                 for test_sample in bio_sample.test_samples.values():
                     for library in test_sample.ngs_libraries.values():
@@ -118,7 +130,13 @@ class ParseSampleSheet:
             yield donor.secondary_id
 
     def yield_sample_and_folder_names(
-        self, sheet, min_batch=None, max_batch=None, batch_key="batchNo", family_key="familyId"
+        self,
+        sheet,
+        min_batch=None,
+        max_batch=None,
+        batch_key="batchNo",
+        family_key="familyId",
+        selected_ids=None,
     ):
         """Yield all sample and folder names (``secondary_id``, ``folderName``) from sheet.
 
@@ -138,8 +156,14 @@ class ParseSampleSheet:
 
         :param family_key: Family identifier key. Default: 'familyId'.
         :type family_key: str
+
+        :param selected_ids: List of samples ids to keep, e.g., 'P001'. Everything else will be ignored.
+        :type selected_ids: list
         """
         for donor in self.yield_donor(sheet, min_batch, max_batch, batch_key, family_key):
+            if selected_ids and donor.secondary_id not in selected_ids:
+                logger.debug(f"Sample '{donor.secondary_id}' not in provided selected id list.")
+                continue
             folder_name = self._get_donor_folder_name(donor) or donor.secondary_id
             yield donor.secondary_id, folder_name
 

--- a/cubi_tk/snappy/pull_all_data.py
+++ b/cubi_tk/snappy/pull_all_data.py
@@ -1,0 +1,152 @@
+"""``cubi-tk snappy pull-all-data``: pull all data from SODAR iRODS to SNAPPY dataset directory.
+More Information
+----------------
+- Also see ``cubi-tk snappy`` :ref:`cli_main <CLI documentation>` and ``cubi-tk snappy pull-sheet --help`` for more information.
+- `SNAPPY Pipeline GitLab Project <https://cubi-gitlab.bihealth.org/CUBI/Pipelines/snappy>`__.
+- `BiomedSheet Documentation <https://biomedsheets.readthedocs.io/en/master/>`__.
+"""
+
+import argparse
+import os
+import typing
+
+import attr
+from logzero import logger
+
+from ..sodar import pull_raw_data as sodar_pull_raw_data
+
+
+@attr.s(frozen=True, auto_attribs=True)
+class Config:
+    """Configuration for the pull-all-data."""
+
+    config: str
+    verbose: bool
+    sodar_server_url: str
+    sodar_url: str
+    sodar_api_token: str = attr.ib(repr=lambda value: "***")  # type: ignore
+    overwrite: bool
+    first_batch: int
+    dry_run: bool
+    irsync_threads: int
+    yes: bool
+    output_directory: str
+    samples: typing.List[str]
+    allow_missing: bool
+    assay_uuid: str
+    project_uuid: str
+
+
+class PullAllDataCommand:
+    """Implementation of the ``snappy pull-all-data`` command."""
+
+    def __init__(self, config: Config):
+        #: Command line arguments.
+        self.config = config
+
+    @classmethod
+    def setup_argparse(cls, parser: argparse.ArgumentParser) -> None:
+        """Setup argument parser."""
+        parser.add_argument(
+            "--hidden-cmd", dest="snappy_cmd", default=cls.run, help=argparse.SUPPRESS
+        )
+        parser.add_argument(
+            "--base-path",
+            default=os.getcwd(),
+            required=False,
+            help=(
+                "Base path of project (contains '.snappy_pipeline/' etc.), spiders up from current "
+                "work directory and falls back to current working directory by default."
+            ),
+        )
+        group_sodar = parser.add_argument_group("SODAR-related")
+        group_sodar.add_argument(
+            "--sodar-url",
+            default=os.environ.get("SODAR_URL", "https://sodar.bihealth.org/"),
+            help="URL to SODAR, defaults to SODAR_URL environment variable or fallback to https://sodar.bihealth.org/",
+        )
+        group_sodar.add_argument(
+            "--sodar-api-token",
+            default=os.environ.get("SODAR_API_TOKEN", None),
+            help="Authentication token when talking to SODAR.  Defaults to SODAR_API_TOKEN environment variable.",
+        )
+        parser.add_argument(
+            "--output-directory",
+            default=None,
+            required=True,
+            help="Output directory, where downloaded files will be stored.",
+        )
+        parser.add_argument(
+            "--overwrite", default=False, action="store_true", help="Allow overwriting of files"
+        )
+        parser.add_argument("--first-batch", default=0, type=int, help="First batch number to pull")
+        parser.add_argument("--samples", help="Optional list of samples to pull")
+        parser.add_argument(
+            "--allow-missing",
+            default=False,
+            action="store_true",
+            help="Allow missing data in assay",
+        )
+        parser.add_argument(
+            "--yes", default=False, action="store_true", help="Assume all answers are yes."
+        )
+        parser.add_argument(
+            "--dry-run",
+            "-n",
+            default=False,
+            action="store_true",
+            help="Perform a dry run, i.e., don't change anything only display change, implies '--show-diff'.",
+        )
+        parser.add_argument("--irsync-threads", help="Parameter -N to pass to irsync")
+        parser.add_argument(
+            "--assay",
+            dest="assay_uuid",
+            default=None,
+            help="UUID of assay to create landing zone for.",
+        )
+        parser.add_argument("project_uuid", help="UUID of project to download data for.")
+
+    @classmethod
+    def run(
+        cls, args, _parser: argparse.ArgumentParser, _subparser: argparse.ArgumentParser
+    ) -> typing.Optional[int]:
+        """Entry point into the command."""
+        args = vars(args)
+        args.pop("cmd", None)
+        args.pop("snappy_cmd", None)
+        args.pop("base_path", None)
+        return cls(Config(**args)).execute()
+
+    def execute(self) -> typing.Optional[int]:
+        """Execute the download."""
+        logger.info("=> will download to %s", self.config.output_directory)
+        logger.info("Using cubi-tk sodar pull-raw-data to actually download data")
+        res = sodar_pull_raw_data.PullRawDataCommand(
+            sodar_pull_raw_data.Config(
+                config=self.config.config,
+                verbose=self.config.verbose,
+                sodar_server_url=self.config.sodar_server_url,
+                sodar_url=self.config.sodar_url,
+                sodar_api_token=self.config.sodar_api_token,
+                overwrite=self.config.overwrite,
+                min_batch=self.config.first_batch,
+                allow_missing=self.config.allow_missing,
+                dry_run=self.config.dry_run,
+                irsync_threads=self.config.irsync_threads,
+                yes=self.config.yes,
+                project_uuid=self.config.project_uuid,
+                assay=self.config.assay_uuid,
+                output_dir=self.config.output_directory,
+            )
+        ).execute()
+
+        if res:
+            logger.error("cubi-tk sodar pull-all-data failed")
+        else:
+            logger.info("All done. Have a nice day!")
+        return res
+
+
+def setup_argparse(parser: argparse.ArgumentParser) -> None:
+    """Setup argument parser for ``cubi-tk snappy pull-all-data``."""
+    return PullAllDataCommand.setup_argparse(parser)

--- a/cubi_tk/snappy/pull_all_data.py
+++ b/cubi_tk/snappy/pull_all_data.py
@@ -1,8 +1,8 @@
 """``cubi-tk snappy pull-all-data``: pull all data from SODAR iRODS to SNAPPY dataset directory.
 More Information
 ----------------
-- Also see ``cubi-tk snappy`` :ref:`cli_main <CLI documentation>` and ``cubi-tk snappy pull-sheet --help`` for more information.
-- `SNAPPY Pipeline GitLab Project <https://cubi-gitlab.bihealth.org/CUBI/Pipelines/snappy>`__.
+- Also see ``cubi-tk snappy`` :ref:`cli_main <CLI documentation>` and ``cubi-tk snappy pull-all-data --help`` for more information.
+- `SNAPPY Pipeline Documentation <https://snappy-pipeline.readthedocs.io/en/latest/>`__.
 - `BiomedSheet Documentation <https://biomedsheets.readthedocs.io/en/master/>`__.
 """
 

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -1,0 +1,139 @@
+from types import SimpleNamespace
+
+from irods.keywords import FORCE_FLAG_KW
+from irods.exception import OVERWRITE_WITHOUT_FORCE_FLAG
+
+from logzero import logger
+from pathlib import Path
+from sodar_cli import api
+
+from ..irods.check import IrodsCheckCommand
+from .retrieve_irods_collection import DEFAULT_HASH_SCHEME
+
+
+#: Valid file extensions
+VALID_FILE_TYPES = ("bam", "vcf", "txt", "csv", "log")
+
+
+class PullDataCommon(IrodsCheckCommand):
+    """Implementation of common pull data methods."""
+
+    #: File type dictionary. Key: file type; Value: additional expected extensions (tuple).
+    file_type_to_extensions_dict = None
+
+    def __init__(self):
+        IrodsCheckCommand.__init__(self, args=SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME))
+
+    def filter_irods_collection(self, identifiers, remote_files_dict, file_type):
+        """Filter iRODS collection based on identifiers (sample id or library name) and file type/extension.
+
+        :param identifiers: List of sample identifiers or library names.
+        :type identifiers: list
+
+        :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
+        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``IrodsDataObject``).
+        :type remote_files_dict: dict
+
+        :param file_type: File type, example: 'bam' or 'vcf'.
+        :type file_type: str
+
+        :return: Returns filtered iRODS collection dictionary.
+        """
+        # Initialise variables
+        filtered_dict = {}
+        extensions_tuple = self.file_type_to_extensions_dict.get(file_type)
+
+        # Iterate
+        for key, value in remote_files_dict.items():
+            # Check for common links
+            # Note: if a file with the same name is present in both assay and in a common file, it will be ignored.
+            in_common_links = False
+            for irods_obj in value:
+                in_common_links = self._irods_path_in_common_links(irods_obj.irods_path)
+                if in_common_links:
+                    break
+
+            # Filter
+            if (
+                any(id_ in key for id_ in identifiers)  # presence of identifiers
+                and key.endswith(extensions_tuple)  # correct file extension
+                and not in_common_links  # not in common links
+            ):
+                filtered_dict[key] = value
+
+        return filtered_dict
+
+    @staticmethod
+    def _irods_path_in_common_links(irods_path):
+        """Checks if iRODS path is from common links, i.e., in 'ResultsReports', 'MiscFiles', 'TrackHubs'.
+
+        :param irods_path: iRODS path
+        :type irods_path: str
+
+        :return: Return True if path is in common links; otherwise, False.
+        """
+        common_links = {"ResultsReports", "MiscFiles", "TrackHubs"}
+        path_part_set = set(irods_path.split("/"))
+        return len(common_links.intersection(path_part_set)) > 0
+
+    def get_assay_uuid(self, sodar_url, sodar_api_token, project_uuid):
+        """Get assay UUID.
+
+        :param sodar_url: SODAR url, e.g.: https://sodar.bihealth.org/
+        :type sodar_url: str
+
+        :param sodar_api_token: SODAR authentication token.
+        :type sodar_api_token: str
+
+        :param project_uuid: SODAR project UUID.
+        :type project_uuid: str
+
+        :return: Returns assay UUID.
+        """
+        investigation = api.samplesheet.retrieve(
+            sodar_url=sodar_url, sodar_api_token=sodar_api_token, project_uuid=project_uuid
+        )
+        for study in investigation.studies.values():
+            for _assay_uuid in study.assays:
+                # If multi-assay project it will only consider the first one
+                return _assay_uuid
+        return None
+
+    def get_irods_files(self, irods_local_path_pairs, force_overwrite=False):
+        """Get iRODS files
+
+        Retrieves iRODS path and stores it locally.
+
+        :param irods_local_path_pairs: List of tuples (iRODS path [str], local output directory [str]).
+        :type irods_local_path_pairs: list
+
+        :param force_overwrite: Flag to indicate if local files should be overwritten.
+        :type force_overwrite: bool
+        """
+        kw_options = {}
+        if force_overwrite:
+            kw_options = {FORCE_FLAG_KW: None}  # Keyword has no value, just needs to be present
+        # Connect to iRODS
+        with self._get_irods_sessions(count=1) as irods_sessions:
+            try:
+                for pair in irods_local_path_pairs:
+                    # Set variable
+                    file_name = pair[0].split("/")[-1]
+                    irods_path = pair[0]
+                    local_out_path = pair[1]
+                    logger.info(f"Retrieving '{file_name}' from: {irods_path}")
+                    # Create output directory if necessary
+                    Path(local_out_path).parent.mkdir(parents=True, exist_ok=True)
+                    # Get file
+                    irods_sessions[0].data_objects.get(irods_path, local_out_path, **kw_options)
+
+            except OVERWRITE_WITHOUT_FORCE_FLAG:
+                logger.error(
+                    f"Failed to retrieve '{file_name}', it already exists in output directory: {local_out_path}"
+                )
+                raise
+            except Exception as e:
+                logger.error(f"Failed to retrieve iRODS path: {irods_path}")
+                logger.error(f"Attempted to copy file to directory: {local_out_path}")
+                logger.error(self.get_irods_error(e))
+                raise

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -141,3 +141,24 @@ class PullDataCommon(IrodsCheckCommand):
                 logger.error(f"Attempted to copy file to directory: {local_out_path}")
                 logger.error(self.get_irods_error(e))
                 raise
+
+    @staticmethod
+    def report_no_file_found(available_files):
+        """Report no files found
+
+        :param available_files: List of available files in SODAR.
+        :type available_files: list
+        """
+        available_files = sorted(available_files)
+        if len(available_files) > 50:
+            limited_str = " (limited to first 50)"
+            ellipsis_ = "..."
+            remote_files_str = "\n".join(available_files[:50])
+        else:
+            limited_str = ""
+            ellipsis_ = ""
+            remote_files_str = "\n".join(available_files)
+        logger.warning(
+            f"No file was found using the selected criteria.\n"
+            f"Available files{limited_str}:\n{remote_files_str}\n{ellipsis_}"
+        )

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -136,6 +136,7 @@ class PullDataCommon(IrodsCheckCommand):
                     f"Failed to retrieve '{file_name}', it already exists in output directory: {local_out_path}"
                 )
                 raise
+
             except Exception as e:
                 logger.error(f"Failed to retrieve iRODS path: {irods_path}")
                 logger.error(f"Attempted to copy file to directory: {local_out_path}")

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -37,7 +37,7 @@ class PullDataCommon(IrodsCheckCommand):
         :param file_type: File type, example: 'bam' or 'vcf'.
         :type file_type: str
 
-        :return: Returns filtered iRODS collection dictionary.
+        :return: Returns dictionary: Key: identifier (sample name [str]); Value: list of iRODS objects.
         """
         # Initialise variables
         filtered_dict = {}
@@ -45,6 +45,11 @@ class PullDataCommon(IrodsCheckCommand):
 
         # Iterate
         for key, value in remote_files_dict.items():
+
+            # Simplify criteria: must have the correct file extension
+            if not key.endswith(extensions_tuple):
+                continue
+
             # Check for common links
             # Note: if a file with the same name is present in both assay and in a common file, it will be ignored.
             in_common_links = False
@@ -56,7 +61,6 @@ class PullDataCommon(IrodsCheckCommand):
             # Filter
             if (
                 any(id_ in key for id_ in identifiers)  # presence of identifiers
-                and key.endswith(extensions_tuple)  # correct file extension
                 and not in_common_links  # not in common links
             ):
                 filtered_dict[key] = value

--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -3,15 +3,13 @@ import os
 from types import SimpleNamespace
 import typing
 
-from irods.exception import OVERWRITE_WITHOUT_FORCE_FLAG
 from logzero import logger
-from pathlib import Path
-from sodar_cli import api
 
 from .common import get_biomedsheet_path, load_sheet_tsv
 from ..common import load_toml_config
-from ..irods.check import IrodsCheckCommand
 from .parse_sample_sheet import ParseSampleSheet
+from .pull_data_common import PullDataCommon
+
 from .retrieve_irods_collection import RetrieveIrodsCollection, DEFAULT_HASH_SCHEME
 
 
@@ -19,7 +17,7 @@ from .retrieve_irods_collection import RetrieveIrodsCollection, DEFAULT_HASH_SCH
 VALID_FILE_TYPES = ("bam", "vcf", "txt", "csv", "log")
 
 
-class PullProcessedDataCommand(IrodsCheckCommand):
+class PullProcessedDataCommand(PullDataCommon):
     """Implementation of the ``pull-processed-data`` command."""
 
     #: File type dictionary. Key: file type; Value: additional expected extensions (tuple).
@@ -32,7 +30,7 @@ class PullProcessedDataCommand(IrodsCheckCommand):
     }
 
     def __init__(self, args):
-        IrodsCheckCommand.__init__(self, args=SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME))
+        PullDataCommon.__init__(self)
         # Command line arguments.
         self.args = args
 
@@ -173,7 +171,11 @@ class PullProcessedDataCommand(IrodsCheckCommand):
         # Get assay UUID if not provided
         assay_uuid = None
         if not self.args.assay_uuid:
-            assay_uuid = self.get_assay_uuuid()
+            assay_uuid = self.get_assay_uuid(
+                sodar_url=self.args.sodar_url,
+                sodar_api_token=self.args.sodar_api_token,
+                project_uuid=self.args.project_uuid,
+            )
 
         # Find all remote files (iRODS)
         pseudo_args = SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME)
@@ -205,7 +207,7 @@ class PullProcessedDataCommand(IrodsCheckCommand):
                 f"No file was found using the selected criteria.\n"
                 f"Available files{limited_str}:\n{remote_files_str}\n{ellipsis_}"
             )
-            return
+            return 0
 
         # Pair iRODS path with output path
         path_pair_list = self.pair_ipath_with_outdir(
@@ -216,6 +218,9 @@ class PullProcessedDataCommand(IrodsCheckCommand):
 
         # Retrieve files from iRODS
         self.get_irods_files(irods_local_path_pairs=path_pair_list)
+
+        logger.info("All done. Have a nice day!")
+        return 0
 
     @staticmethod
     def pair_ipath_with_outdir(remote_files_dict, output_dir, assay_uuid):
@@ -245,119 +250,19 @@ class PullProcessedDataCommand(IrodsCheckCommand):
                     irods_dir_structure = os.path.dirname(
                         str(irods_obj.irods_path).split(f"assay_{assay_uuid}/")[1]
                     )
-                    _out_dir = os.path.join(output_dir, irods_dir_structure)
+                    _out_path = os.path.join(output_dir, irods_dir_structure, irods_obj.file_name)
                 except IndexError:
                     logger.warning(
                         f"Provided Assay UUID '{assay_uuid}' is not present in SODAR path, "
                         f"hence directory structure won't be preserved.\n"
                         f"All files will be stored in root of output directory: {output_list}"
                     )
-                    _out_dir = output_dir
+                    _out_path = os.path.join(output_dir, irods_obj.file_name)
                 # Update output
-                output_list.append((irods_obj.irods_path, _out_dir))
-                output_list.append((irods_obj.irods_path + ".md5", _out_dir))
+                output_list.append((irods_obj.irods_path, _out_path))
+                output_list.append((irods_obj.irods_path + ".md5", _out_path + ".md5"))
 
         return output_list
-
-    def filter_irods_collection(self, identifiers, remote_files_dict, file_type):
-        """Filter iRODS collection based on identifiers (sample id or library name) and file type/extension.
-
-        :param identifiers: List of sample identifiers or library names.
-        :type identifiers: list
-
-        :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001-N1-DNA1-WES1'); Value: iRODS data (``IrodsDataObject``).
-        :type remote_files_dict: dict
-
-        :param file_type: File type, example: 'bam' or 'vcf'.
-        :type file_type: str
-
-        :return: Returns filtered iRODS collection dictionary.
-        """
-        # Initialise variables
-        filtered_dict = {}
-
-        extensions_tuple = self.file_type_to_extensions_dict.get(file_type)
-
-        # Iterate
-        for key, value in remote_files_dict.items():
-            # Check for common links
-            # Note: if a file with the same name is present in both assay and in a common file, it will be ignored.
-            in_common_links = False
-            for irods_obj in value:
-                in_common_links = self._irods_path_in_common_links(irods_obj.irods_path)
-                if in_common_links:
-                    break
-
-            # Filter
-            if (
-                any(id_ in key for id_ in identifiers)  # presence of identifiers
-                and key.endswith(extensions_tuple)  # correct file extension
-                and not in_common_links  # not in common links
-            ):
-                filtered_dict[key] = value
-
-        return filtered_dict
-
-    @staticmethod
-    def _irods_path_in_common_links(irods_path):
-        """Checks if iRODS path is from common links, i.e., in 'ResultsReports', 'MiscFiles', 'TrackHubs'.
-
-        :param irods_path: iRODS path
-        :type irods_path: str
-
-        :return: Return True if path is in common links; otherwise, False.
-        """
-        common_links = {"ResultsReports", "MiscFiles", "TrackHubs"}
-        path_part_set = set(irods_path.split("/"))
-        return len(common_links.intersection(path_part_set)) > 0
-
-    def get_assay_uuuid(self):
-        """Get assay UUID.
-
-        :return: Returns assay UUID.
-        """
-        investigation = api.samplesheet.retrieve(
-            sodar_url=self.args.sodar_url,
-            sodar_api_token=self.args.sodar_api_token,
-            project_uuid=self.args.project_uuid,
-        )
-        for study in investigation.studies.values():
-            for _assay_uuid in study.assays:
-                # If multi-assay project it will only consider the first one
-                return _assay_uuid
-        return None
-
-    def get_irods_files(self, irods_local_path_pairs):
-        """Get iRODS files
-
-        Retrieves iRODS path and stores it locally.
-
-        :param irods_local_path_pairs:
-        """
-        # Connect to iRODS
-        with self._get_irods_sessions(count=1) as irods_sessions:
-            try:
-                for pair in irods_local_path_pairs:
-                    # Set variable
-                    file_name = pair[0].split("/")[-1]
-                    irods_path = pair[0]
-                    out_dir = pair[1]
-                    logger.info(f"Retrieving '{file_name}' from: {irods_path}")
-                    # Create output directory if necessary
-                    Path(out_dir).mkdir(parents=True, exist_ok=True)
-                    # Get file
-                    irods_sessions[0].data_objects.get(irods_path, out_dir)
-
-            except OVERWRITE_WITHOUT_FORCE_FLAG:
-                logger.error(
-                    f"Failed to retrieve '{file_name}', it already exists in output directory: {out_dir}"
-                )
-            except Exception as e:
-                logger.error(f"Failed to retrieve iRODS path: {irods_path}")
-                logger.error(f"Attempted to copy file to directory: {out_dir}")
-                logger.error(self.get_irods_error(e))
-                raise
 
 
 def setup_argparse(parser: argparse.ArgumentParser) -> None:

--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -194,19 +194,7 @@ class PullProcessedDataCommand(PullDataCommon):
             file_type=self.args.file_type,
         )
         if len(filtered_remote_files_dict) == 0:
-            if len(remote_files_dict) > 50:
-                limited_str = " (limited to first 50)"
-                ellipsis_ = "..."
-                remote_files_str = "\n".join([*remote_files_dict][:50])
-            else:
-                limited_str = ""
-                ellipsis_ = ""
-                remote_files_str = "\n".join([*remote_files_dict])
-
-            logger.warning(
-                f"No file was found using the selected criteria.\n"
-                f"Available files{limited_str}:\n{remote_files_str}\n{ellipsis_}"
-            )
+            self.report_no_file_found(available_files=[*remote_files_dict])
             return 0
 
         # Pair iRODS path with output path

--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -1,3 +1,10 @@
+"""``cubi-tk snappy pull-processed-data``: pull processed data from SODAR iRODS to output directory.
+More Information
+----------------
+- Also see ``cubi-tk snappy`` :ref:`cli_main <CLI documentation>` and ``cubi-tk snappy pull-processed-data --help`` for more information.
+- `SNAPPY Pipeline Documentation <https://snappy-pipeline.readthedocs.io/en/latest/>`__.
+- `BiomedSheet Documentation <https://biomedsheets.readthedocs.io/en/master/>`__.
+"""
 import argparse
 import os
 from types import SimpleNamespace

--- a/cubi_tk/snappy/pull_raw_data.py
+++ b/cubi_tk/snappy/pull_raw_data.py
@@ -161,13 +161,19 @@ class PullRawDataCommand(PullDataCommon):
         if self.config.sodar_directory:
             selected_identifiers_tuples = list(
                 parser.yield_ngs_library_and_folder_names(
-                    sheet=sheet, min_batch=self.config.first_batch, max_batch=self.config.last_batch
+                    sheet=sheet,
+                    min_batch=self.config.first_batch,
+                    max_batch=self.config.last_batch,
+                    selected_ids=self.config.samples,
                 )
             )
         else:
             selected_identifiers_tuples = list(
                 parser.yield_sample_and_folder_names(
-                    sheet=sheet, min_batch=self.config.first_batch, max_batch=self.config.last_batch
+                    sheet=sheet,
+                    min_batch=self.config.first_batch,
+                    max_batch=self.config.last_batch,
+                    selected_ids=self.config.samples,
                 )
             )
         selected_identifiers = [pair[0] for pair in selected_identifiers_tuples]

--- a/cubi_tk/snappy/pull_raw_data.py
+++ b/cubi_tk/snappy/pull_raw_data.py
@@ -1,10 +1,8 @@
-"""``cubi-tk snappy pull-raw-data``: pull raw data from SODAR iRODS to SNAPPY dataset directory.
-
+"""``cubi-tk snappy pull-raw-data``: pull raw data (i.e., FASTQ files) from SODAR iRODS to SNAPPY dataset directory.
 More Information
 ----------------
-
-- Also see ``cubi-tk snappy`` :ref:`cli_main <CLI documentation>` and ``cubi-tk snappy pull-sheet --help`` for more information.
-- `SNAPPY Pipeline GitLab Project <https://cubi-gitlab.bihealth.org/CUBI/Pipelines/snappy>`__.
+- Also see ``cubi-tk snappy`` :ref:`cli_main <CLI documentation>` and ``cubi-tk snappy pull-raw-data --help`` for more information.
+- `SNAPPY Pipeline Documentation <https://snappy-pipeline.readthedocs.io/en/latest/>`__.
 - `BiomedSheet Documentation <https://biomedsheets.readthedocs.io/en/master/>`__.
 """
 

--- a/tests/test_snappy_parse_sample_sheet.py
+++ b/tests/test_snappy_parse_sample_sheet.py
@@ -55,6 +55,39 @@ def test_yield_ngs_library_names(parser, sheet):
         assert name_ in expected_batch_three
 
 
+def test_yield_ngs_library_and_folder_names(parser, sheet):
+    """Tests ParseSampleSheet.yield_ngs_library_and_folder_names()"""
+    # Define expected
+    expected_batch_one = [(f"P00{i}-N1-DNA1-WGS1", f"P00{i}") for i in (1, 2, 3)]
+    expected_batch_two = [(f"P00{i}-N1-DNA1-WGS1", f"P00{i}") for i in (4, 5, 6)]
+    expected_batch_three = [("P007-N1-DNA1-WGS1", "P007")]
+
+    # Test max batch = 1
+    actual = parser.yield_ngs_library_and_folder_names(sheet=sheet, max_batch=1)
+    for name_ in actual:
+        assert name_ in expected_batch_one
+
+    # Test min batch = 2
+    actual = parser.yield_ngs_library_and_folder_names(sheet=sheet, min_batch=2)
+    for name_ in actual:
+        expected_list = expected_batch_two + expected_batch_three
+        assert name_ in expected_list
+
+    # Test min batch = 3
+    actual = parser.yield_ngs_library_and_folder_names(sheet=sheet, min_batch=3)
+    for name_ in actual:
+        assert name_ in expected_batch_three
+
+
+def test_yield_ngs_library_and_folder_names_filter(parser, sheet):
+    """Tests ParseSampleSheet.yield_ngs_library_and_folder_names()"""
+    filter_ids_input = [f"P00{i}" for i in (1, 2, 3, 5)]
+    expected = [(f"P00{i}-N1-DNA1-WGS1", f"P00{i}") for i in (1, 2, 3, 5)]
+    actual = parser.yield_ngs_library_and_folder_names(sheet=sheet, selected_ids=filter_ids_input)
+    for name_ in actual:
+        assert name_ in expected
+
+
 def test_yield_ngs_library_names_multi_batch(parser, sheet_multi_batch):
     """Tests ParseSampleSheet.yield_ngs_library_names() - multiple batches in sample sheet"""
     # Define expected
@@ -136,6 +169,15 @@ def test_yield_sample_names(parser, sheet):
     actual = parser.yield_sample_names(sheet=sheet, min_batch=3)
     for name_ in actual:
         assert name_ in expected_batch_three
+
+
+def test_yield_sample_and_folder_names_filter(parser, sheet):
+    """Tests ParseSampleSheet.yield_sample_and_folder_names()"""
+    selected_ids_input = [f"P00{i}" for i in (1, 2, 3)]
+    expected = [(f"P00{i}", f"P00{i}") for i in (1, 2, 3)]
+    actual = parser.yield_sample_and_folder_names(sheet=sheet, selected_ids=selected_ids_input)
+    for name_ in actual:
+        assert name_ in expected
 
 
 def test_yield_sample_and_folder_names_batch_one(parser, sheet):

--- a/tests/test_snappy_parse_sample_sheet.py
+++ b/tests/test_snappy_parse_sample_sheet.py
@@ -1,6 +1,7 @@
 """Tests for ``cubi_tk.snappy.parse_sample_sheet``."""
 
 import pathlib
+import pytest
 
 from biomedsheets.io_tsv import read_germline_tsv_sheet
 from biomedsheets.naming import NAMING_ONLY_SECONDARY_ID
@@ -8,20 +9,34 @@ from biomedsheets.naming import NAMING_ONLY_SECONDARY_ID
 from cubi_tk.snappy.parse_sample_sheet import ParseSampleSheet
 
 
-def test_yield_ngs_library_names():
-    """Tests ParseSampleSheet.yield_ngs_library_names()"""
-    # Instantiate
-    parser = ParseSampleSheet()
+@pytest.fixture
+def parser():
+    """Returns instantiated ParserSampleSheet"""
+    return ParseSampleSheet()
 
+
+@pytest.fixture
+def sheet():
+    """Returns sample sheet"""
+    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet.tsv"
+    with open(sheet_path, "rt") as f_sheet:
+        return read_germline_tsv_sheet(f=f_sheet, naming_scheme=NAMING_ONLY_SECONDARY_ID)
+
+
+@pytest.fixture
+def sheet_multi_batch():
+    """Returns sample sheet with multiple batches"""
+    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet_multi_batch.tsv"
+    with open(sheet_path, "rt") as f_sheet:
+        return read_germline_tsv_sheet(f=f_sheet, naming_scheme=NAMING_ONLY_SECONDARY_ID)
+
+
+def test_yield_ngs_library_names(parser, sheet):
+    """Tests ParseSampleSheet.yield_ngs_library_names()"""
     # Define expected
     expected_batch_one = [f"P00{i}-N1-DNA1-WGS1" for i in (1, 2, 3)]
     expected_batch_two = [f"P00{i}-N1-DNA1-WGS1" for i in (4, 5, 6)]
     expected_batch_three = ["P007-N1-DNA1-WGS1"]
-
-    # Define input
-    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet.tsv"
-    with open(sheet_path, "rt") as f_sheet:
-        sheet = read_germline_tsv_sheet(f=f_sheet, naming_scheme=NAMING_ONLY_SECONDARY_ID)
 
     # Test max batch = 1
     actual = parser.yield_ngs_library_names(sheet=sheet, max_batch=1)
@@ -40,11 +55,8 @@ def test_yield_ngs_library_names():
         assert name_ in expected_batch_three
 
 
-def test_yield_ngs_library_names_multi_batch():
+def test_yield_ngs_library_names_multi_batch(parser, sheet_multi_batch):
     """Tests ParseSampleSheet.yield_ngs_library_names() - multiple batches in sample sheet"""
-    # Instantiate
-    parser = ParseSampleSheet()
-
     # Define expected
     expected_batch_one = ["P001-N1-DNA1-WGS1", "P002-N1-DNA1-WGS1", "P003-N1-DNA1-WGS1"]
     expected_batch_two = ["P004-N1-DNA1-WGS1", "P005-N1-DNA1-WGS1", "P006-N1-DNA1-WGS1"]
@@ -53,13 +65,8 @@ def test_yield_ngs_library_names_multi_batch():
     expected_batch_five = ["P013-N1-DNA1-WGS1", "P014-N1-DNA1-WGS1"]
     expected_batch_six = ["P015-N1-DNA1-WGS1"]
 
-    # Define input
-    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet_multi_batch.tsv"
-    with open(sheet_path, "rt") as f_sheet:
-        sheet = read_germline_tsv_sheet(f=f_sheet, naming_scheme=NAMING_ONLY_SECONDARY_ID)
-
     # Sanity test - no constraints
-    actual = parser.yield_ngs_library_names(sheet=sheet, min_batch=None, max_batch=None)
+    actual = parser.yield_ngs_library_names(sheet=sheet_multi_batch, min_batch=None, max_batch=None)
     expected_list = (
         expected_batch_one
         + expected_batch_two
@@ -72,7 +79,7 @@ def test_yield_ngs_library_names_multi_batch():
         assert name_ in expected_list
 
     # Test min batch = 2, max batch = None
-    actual = parser.yield_ngs_library_names(sheet=sheet, min_batch=2, max_batch=None)
+    actual = parser.yield_ngs_library_names(sheet=sheet_multi_batch, min_batch=2, max_batch=None)
     expected_list = (
         expected_batch_two
         + expected_batch_three
@@ -83,44 +90,36 @@ def test_yield_ngs_library_names_multi_batch():
     for name_ in actual:
         assert name_ in expected_list
     # Test min batch = 2, max batch = 3
-    actual = parser.yield_ngs_library_names(sheet=sheet, min_batch=2, max_batch=3)
+    actual = parser.yield_ngs_library_names(sheet=sheet_multi_batch, min_batch=2, max_batch=3)
     expected_list = expected_batch_two + expected_batch_three
     for name_ in actual:
         assert name_ in expected_list
 
     # Test min batch = 3, max batch = 5
-    actual = parser.yield_ngs_library_names(sheet=sheet, min_batch=3, max_batch=5)
+    actual = parser.yield_ngs_library_names(sheet=sheet_multi_batch, min_batch=3, max_batch=5)
     expected_list = expected_batch_three + expected_batch_four + expected_batch_five
     for name_ in actual:
         assert name_ in expected_list
 
     # Test min batch = 5, max batch = 5
-    actual = parser.yield_ngs_library_names(sheet=sheet, min_batch=5, max_batch=5)
+    actual = parser.yield_ngs_library_names(sheet=sheet_multi_batch, min_batch=5, max_batch=5)
     expected_list = expected_batch_five
     for name_ in actual:
         assert name_ in expected_list
 
     # Test min batch = 6, max batch = 6
-    actual = parser.yield_ngs_library_names(sheet=sheet, min_batch=6, max_batch=6)
+    actual = parser.yield_ngs_library_names(sheet=sheet_multi_batch, min_batch=6, max_batch=6)
     expected_list = expected_batch_six
     for name_ in actual:
         assert name_ in expected_list
 
 
-def test_yield_sample_names():
+def test_yield_sample_names(parser, sheet):
     """Tests ParseSampleSheet.yield_sample_names()"""
-    # Instantiate
-    parser = ParseSampleSheet()
-
     # Define expected
     expected_batch_one = [f"P00{i}" for i in (1, 2, 3)]
     expected_batch_two = [f"P00{i}" for i in (4, 5, 6)]
     expected_batch_three = ["P007"]
-
-    # Define input
-    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet.tsv"
-    with open(sheet_path, "rt") as f_sheet:
-        sheet = read_germline_tsv_sheet(f=f_sheet, naming_scheme=NAMING_ONLY_SECONDARY_ID)
 
     # Test max batch = 1
     actual = parser.yield_sample_names(sheet=sheet, max_batch=1)
@@ -139,11 +138,33 @@ def test_yield_sample_names():
         assert name_ in expected_batch_three
 
 
-def test_yield_sample_names_multi_batch():
-    """Tests ParseSampleSheet.yield_sample_names() - multiple batches in sample sheet"""
-    # Instantiate
-    parser = ParseSampleSheet()
+def test_yield_sample_and_folder_names_batch_one(parser, sheet):
+    """Tests ParseSampleSheet.yield_sample_and_folder_names()"""
+    expected_batch_one = [(f"P00{i}", f"P00{i}") for i in (1, 2, 3)]
+    actual = parser.yield_sample_and_folder_names(sheet=sheet, max_batch=1)
+    for name_ in actual:
+        assert name_ in expected_batch_one
 
+
+def test_yield_sample_and_folder_names_batch_two(parser, sheet):
+    """Tests ParseSampleSheet.yield_sample_and_folder_names()"""
+    expected_batch_two = [(f"P00{i}", f"P00{i}") for i in (4, 5, 6, 7)]
+    actual = parser.yield_sample_and_folder_names(sheet=sheet, min_batch=2)
+    for name_ in actual:
+        expected_list = expected_batch_two
+        assert name_ in expected_list
+
+
+def test_yield_sample_and_folder_names_batch_three(parser, sheet):
+    """Tests ParseSampleSheet.yield_sample_and_folder_names()"""
+    expected_batch_three = [("P007", "P007")]
+    actual = parser.yield_sample_and_folder_names(sheet=sheet, min_batch=3)
+    for name_ in actual:
+        assert name_ in expected_batch_three
+
+
+def test_yield_sample_names_multi_batch(parser, sheet_multi_batch):
+    """Tests ParseSampleSheet.yield_sample_names() - multiple batches in sample sheet"""
     # Define expected
     expected_batch_one = [f"P00{i}" for i in (1, 2, 3)]
     expected_batch_two = [f"P00{i}" for i in (4, 5, 6)]
@@ -152,13 +173,8 @@ def test_yield_sample_names_multi_batch():
     expected_batch_five = [f"P0{i}" for i in (13, 14)]
     expected_batch_six = ["P015"]
 
-    # Define input
-    sheet_path = pathlib.Path(__file__).resolve().parent / "data" / "germline_sheet_multi_batch.tsv"
-    with open(sheet_path, "rt") as f_sheet:
-        sheet = read_germline_tsv_sheet(f=f_sheet, naming_scheme=NAMING_ONLY_SECONDARY_ID)
-
     # Sanity test - no constraints
-    actual = parser.yield_sample_names(sheet=sheet, min_batch=None, max_batch=None)
+    actual = parser.yield_sample_names(sheet=sheet_multi_batch, min_batch=None, max_batch=None)
     expected_list = (
         expected_batch_one
         + expected_batch_two
@@ -171,7 +187,7 @@ def test_yield_sample_names_multi_batch():
         assert name_ in expected_list
 
     # Test min batch = 2, max batch = None
-    actual = parser.yield_sample_names(sheet=sheet, min_batch=2, max_batch=None)
+    actual = parser.yield_sample_names(sheet=sheet_multi_batch, min_batch=2, max_batch=None)
     expected_list = (
         expected_batch_two
         + expected_batch_three
@@ -182,25 +198,25 @@ def test_yield_sample_names_multi_batch():
     for name_ in actual:
         assert name_ in expected_list
     # Test min batch = 2, max batch = 3
-    actual = parser.yield_sample_names(sheet=sheet, min_batch=2, max_batch=3)
+    actual = parser.yield_sample_names(sheet=sheet_multi_batch, min_batch=2, max_batch=3)
     expected_list = expected_batch_two + expected_batch_three
     for name_ in actual:
         assert name_ in expected_list
 
     # Test min batch = 3, max batch = 5
-    actual = parser.yield_sample_names(sheet=sheet, min_batch=3, max_batch=5)
+    actual = parser.yield_sample_names(sheet=sheet_multi_batch, min_batch=3, max_batch=5)
     expected_list = expected_batch_three + expected_batch_four + expected_batch_five
     for name_ in actual:
         assert name_ in expected_list
 
     # Test min batch = 5, max batch = 5
-    actual = parser.yield_sample_names(sheet=sheet, min_batch=5, max_batch=5)
+    actual = parser.yield_sample_names(sheet=sheet_multi_batch, min_batch=5, max_batch=5)
     expected_list = expected_batch_five
     for name_ in actual:
         assert name_ in expected_list
 
     # Test min batch = 6, max batch = 6
-    actual = parser.yield_sample_names(sheet=sheet, min_batch=6, max_batch=6)
+    actual = parser.yield_sample_names(sheet=sheet_multi_batch, min_batch=6, max_batch=6)
     expected_list = expected_batch_six
     for name_ in actual:
         assert name_ in expected_list

--- a/tests/test_snappy_pull_processed_data.py
+++ b/tests/test_snappy_pull_processed_data.py
@@ -456,27 +456,38 @@ def test_pull_processed_data_pair_ipath_with_outdir_bam(pull_processed_data, rem
         "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P00{i}-N1-DNA1-WES1/1999-09-09/ngs_mapping/"
         "bwa.P00{i}-N1-DNA1-WES1.{ext}"
     )
-    full_out_dir = "out_dir/P00{i}-N1-DNA1-WES1/1999-09-09/ngs_mapping"
+    full_out_dir = (
+        "out_dir/P00{i}-N1-DNA1-WES1/1999-09-09/ngs_mapping/bwa.P00{i}-N1-DNA1-WES1.{ext}"
+    )
     irods_files_list = [
         irods_path.format(i=i, ext=ext)
         for i in (1, 2)
         for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
     ]
-    output_dir_list = [full_out_dir.format(i=1)] * 4 + [full_out_dir.format(i=2)] * 4
+    correct_uuid_output_dir_list = [
+        full_out_dir.format(i=i, ext=ext)
+        for i in (1, 2)
+        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+    ]
+    wrong_uuid_output_dir_list = [
+        "out_dir/bwa.P00{i}-N1-DNA1-WES1.{ext}".format(i=i, ext=ext)
+        for i in (1, 2)
+        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+    ]
     correct_uuid_expected = []
-    for _irods_path, _out_path in zip(irods_files_list, output_dir_list):
+    for _irods_path, _out_path in zip(irods_files_list, correct_uuid_output_dir_list):
         correct_uuid_expected.append((_irods_path, _out_path))
     wrong_uuid_expected = []
-    for _irods_path, _out_path in zip(irods_files_list, [out_dir] * 8):
+    for _irods_path, _out_path in zip(irods_files_list, wrong_uuid_output_dir_list):
         wrong_uuid_expected.append((_irods_path, _out_path))
 
-    # Test with correct assay UUID
+    # Test with correct assay UUID - directory structure same as in SODAR
     actual = pull_processed_data.pair_ipath_with_outdir(
         remote_files_dict=remote_files_bam, output_dir=out_dir, assay_uuid=assay_uuid
     )
     assert sorted(actual) == sorted(correct_uuid_expected)
 
-    # Test with wrong assay UUID
+    # Test with wrong assay UUID - all files copied to root of output directory
     actual = pull_processed_data.pair_ipath_with_outdir(
         remote_files_dict=remote_files_bam, output_dir=out_dir, assay_uuid=wrong_assay_uuid
     )
@@ -495,27 +506,38 @@ def test_pull_processed_data_pair_ipath_with_outdir_vcf(pull_processed_data, rem
         "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P00{i}-N1-DNA1-WES1/1999-09-09/variant_calling/"
         "bwa.P00{i}-N1-DNA1-WES1.{ext}"
     )
-    full_out_dir = "out_dir/P00{i}-N1-DNA1-WES1/1999-09-09/variant_calling"
+    full_out_dir = (
+        "out_dir/P00{i}-N1-DNA1-WES1/1999-09-09/variant_calling/bwa.P00{i}-N1-DNA1-WES1.{ext}"
+    )
     irods_files_list = [
         irods_path.format(i=i, ext=ext)
         for i in (1, 2)
         for ext in ("vcf.gz", "vcf.gz.tbi", "vcf.gz.md5", "vcf.gz.tbi.md5")
     ]
-    output_dir_list = [full_out_dir.format(i=1)] * 4 + [full_out_dir.format(i=2)] * 4
+    correct_uuid_output_dir_list = [
+        full_out_dir.format(i=i, ext=ext)
+        for i in (1, 2)
+        for ext in ("vcf.gz", "vcf.gz.tbi", "vcf.gz.md5", "vcf.gz.tbi.md5")
+    ]
+    wrong_uuid_output_dir_list = [
+        "out_dir/bwa.P00{i}-N1-DNA1-WES1.{ext}".format(i=i, ext=ext)
+        for i in (1, 2)
+        for ext in ("vcf.gz", "vcf.gz.tbi", "vcf.gz.md5", "vcf.gz.tbi.md5")
+    ]
     correct_uuid_expected = []
-    for _irods_path, _out_path in zip(irods_files_list, output_dir_list):
+    for _irods_path, _out_path in zip(irods_files_list, correct_uuid_output_dir_list):
         correct_uuid_expected.append((_irods_path, _out_path))
     wrong_uuid_expected = []
-    for _irods_path, _out_path in zip(irods_files_list, [out_dir] * 8):
+    for _irods_path, _out_path in zip(irods_files_list, wrong_uuid_output_dir_list):
         wrong_uuid_expected.append((_irods_path, _out_path))
 
-    # Test with correct assay UUID
+    # Test with correct assay UUID - directory structure same as in SODAR
     actual = pull_processed_data.pair_ipath_with_outdir(
         remote_files_dict=remote_files_vcf, output_dir=out_dir, assay_uuid=assay_uuid
     )
     assert sorted(actual) == sorted(correct_uuid_expected)
 
-    # Test with wrong assay UUID
+    # Test with wrong assay UUID - all files copied to root of output directory
     actual = pull_processed_data.pair_ipath_with_outdir(
         remote_files_dict=remote_files_vcf, output_dir=out_dir, assay_uuid=wrong_assay_uuid
     )

--- a/tests/test_snappy_pull_raw_data.py
+++ b/tests/test_snappy_pull_raw_data.py
@@ -25,6 +25,7 @@ def pull_raw_data():
         "sodar_url": "https://sodar.bihealth.org/",
         "dry_run": False,
         "overwrite": False,
+        "sodar_directory": None,
         "tsv_shortcut": "germline",
         "first_batch": 0,
         "last_batch": None,
@@ -199,9 +200,7 @@ def test_run_snappy_pull_raw_nothing(capsys):
     assert res.err
 
 
-def test_pull_raw_data_filter_irods_collection_fastq(
-    pull_raw_data, remote_files_fastq, remote_files_all
-):
+def test_pull_raw_data_filter_irods_collection(pull_raw_data, remote_files_fastq, remote_files_all):
     """Tests PullRawDataCommand.filter_irods_collection() - FASTQ files"""
     # Define input
     absent_sample_list = ["P098", "P099"]
@@ -217,6 +216,35 @@ def test_pull_raw_data_filter_irods_collection_fastq(
     # Sanity check - should return empty dictionary, samples aren't present
     actual = pull_raw_data.filter_irods_collection(
         identifiers=absent_sample_list, remote_files_dict=remote_files_fastq, file_type=file_type
+    )
+    assert len(actual) == 0
+
+
+def test_pull_raw_data_filter_irods_collection_plus_dir_name(
+    pull_raw_data, remote_files_fastq, remote_files_all, library_to_irods_dict
+):
+    """Tests PullRawDataCommand.filter_irods_collection_plus_dir_name() - FASTQ files"""
+    # Define input
+    absent_sample_list = ["P098", "P099"]
+    samples_list = ["P001", "P002"]
+    file_type = "fastq"
+
+    # Call with samples id as identifiers
+    actual = pull_raw_data.filter_irods_collection_plus_dir_name(
+        identifiers=samples_list,
+        directory_name="raw_data",
+        remote_files_dict=remote_files_all,
+        file_type=file_type,
+    )
+    print(actual)
+    assert actual == library_to_irods_dict
+
+    # Sanity check - should return empty dictionary, samples aren't present
+    actual = pull_raw_data.filter_irods_collection_plus_dir_name(
+        identifiers=absent_sample_list,
+        directory_name="raw_data",
+        remote_files_dict=remote_files_fastq,
+        file_type=file_type,
     )
     assert len(actual) == 0
 

--- a/tests/test_snappy_pull_raw_data.py
+++ b/tests/test_snappy_pull_raw_data.py
@@ -236,7 +236,6 @@ def test_pull_raw_data_filter_irods_collection_plus_dir_name(
         remote_files_dict=remote_files_all,
         file_type=file_type,
     )
-    print(actual)
     assert actual == library_to_irods_dict
 
     # Sanity check - should return empty dictionary, samples aren't present

--- a/tests/test_snappy_pull_raw_data.py
+++ b/tests/test_snappy_pull_raw_data.py
@@ -1,0 +1,305 @@
+"""Tests for ``cubi_tk.snappy.pull_raw_data``.
+"""
+
+import pytest
+
+from cubi_tk.snappy.pull_raw_data import Config, PullRawDataCommand
+from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+from cubi_tk.__main__ import setup_argparse
+
+# Empty file MD5 checksum
+FILE_MD5SUM = "d41d8cd98f00b204e9800998ecf8427e"
+
+# Arbitrary replicas MD5 checksum value
+REPLICAS_MD5SUM = [FILE_MD5SUM] * 3
+
+
+@pytest.fixture
+def pull_raw_data():
+    """Returns instantiated PullRawDataCommand"""
+    args_dict = {
+        "verbose": False,
+        "sodar_server_url": "https://sodar.bihealth.org/",
+        "sodar_api_token": "__secret__",
+        "base_path": ".",
+        "sodar_url": "https://sodar.bihealth.org/",
+        "dry_run": False,
+        "overwrite": False,
+        "tsv_shortcut": "germline",
+        "first_batch": 0,
+        "last_batch": None,
+        "samples": None,
+        "assay_uuid": None,
+        "project_uuid": "99999999-aaaa-bbbb-cccc-99999999",
+    }
+    return PullRawDataCommand(Config(**args_dict))
+
+
+@pytest.fixture
+def remote_files_fastq():
+    """Returns iRODS collection example for BAM files and two samples, P001 and P002"""
+    p0001_sodar_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P001-N1-DNA1-WES1/1999-09-09"
+    )
+    p0002_sodar_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P002-N1-DNA1-WES1/1999-09-09"
+    )
+    return {
+        "P001_R1_001.fastq.gz": [
+            IrodsDataObject(
+                file_name="P001_R1_001.fastq.gz",
+                irods_path=f"{p0001_sodar_path}/raw_data/P001_R1_001.fastq.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            )
+        ],
+        "P001_R2_001.fastq.gz": [
+            IrodsDataObject(
+                file_name="P001_R2_001.fastq.gz",
+                irods_path=f"{p0001_sodar_path}/raw_data/P001_R2_001.fastq.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            )
+        ],
+        "P002_R1_001.fastq.gz": [
+            IrodsDataObject(
+                file_name="P002_R1_001.fastq.gz",
+                irods_path=f"{p0002_sodar_path}/raw_data/P002_R1_001.fastq.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            )
+        ],
+        "P002_R2_001.fastq.gz": [
+            IrodsDataObject(
+                file_name="P002_R2_001.fastq.gz",
+                irods_path=f"{p0002_sodar_path}/raw_data/P002_R2_001.fastq.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            )
+        ],
+    }
+
+
+@pytest.fixture
+def remote_files_vcf():
+    """Returns iRODS collection example for VCF files and two samples, P001 and P002"""
+    p0001_sodar_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P001-N1-DNA1-WES1/1999-09-09"
+    )
+    p0002_sodar_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P002-N1-DNA1-WES1/1999-09-09"
+    )
+    return {
+        "bwa.P001-N1-DNA1-WES1.vcf.gz": [
+            IrodsDataObject(
+                file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+                irods_path=f"{p0001_sodar_path}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            )
+        ],
+        "bwa.P001-N1-DNA1-WES1.vcf.gz.tbi": [
+            IrodsDataObject(
+                file_name="bwa.P001-N1-DNA1-WES1.vcf.gz.tbi",
+                irods_path=f"{p0001_sodar_path}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz.tbi",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            )
+        ],
+        "bwa.P002-N1-DNA1-WES1.vcf.gz": [
+            IrodsDataObject(
+                file_name="bwa.P002-N1-DNA1-WES1.vcf.gz",
+                irods_path=f"{p0002_sodar_path}/variant_calling/bwa.P002-N1-DNA1-WES1.vcf.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            )
+        ],
+        "bwa.P002-N1-DNA1-WES1.vcf.gz.tbi": [
+            IrodsDataObject(
+                file_name="bwa.P002-N1-DNA1-WES1.vcf.gz.tbi",
+                irods_path=f"{p0002_sodar_path}/variant_calling/bwa.P002-N1-DNA1-WES1.vcf.gz.tbi",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            )
+        ],
+    }
+
+
+@pytest.fixture
+def remote_files_all(remote_files_fastq, remote_files_vcf):
+    """Returns full example of iRODS collection: FASTQ and VCF files"""
+    return {**remote_files_fastq, **remote_files_vcf}
+
+
+@pytest.fixture
+def library_to_irods_dict():
+    """Returns example of output from PullRawDataCommand.pair_ipath_with_folder_name()"""
+    p0001_sodar_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P001-N1-DNA1-WES1/1999-09-09"
+    )
+    p0002_sodar_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P002-N1-DNA1-WES1/1999-09-09"
+    )
+    return {
+        "P001": [
+            IrodsDataObject(
+                file_name="P001_R1_001.fastq.gz",
+                irods_path=f"{p0001_sodar_path}/raw_data/P001_R1_001.fastq.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            ),
+            IrodsDataObject(
+                file_name="P001_R2_001.fastq.gz",
+                irods_path=f"{p0001_sodar_path}/raw_data/P001_R2_001.fastq.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            ),
+        ],
+        "P002": [
+            IrodsDataObject(
+                file_name="P002_R1_001.fastq.gz",
+                irods_path=f"{p0002_sodar_path}/raw_data/P002_R1_001.fastq.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            ),
+            IrodsDataObject(
+                file_name="P002_R2_001.fastq.gz",
+                irods_path=f"{p0002_sodar_path}/raw_data/P002_R2_001.fastq.gz",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            ),
+        ],
+    }
+
+
+def test_run_snappy_pull_raw_help(capsys):
+    """Test ``cubi-tk snappy pull-raw-data --help``"""
+    parser, _subparsers = setup_argparse()
+    with pytest.raises(SystemExit) as e:
+        parser.parse_args(["snappy", "pull-raw-data", "--help"])
+
+    assert e.value.code == 0
+
+    res = capsys.readouterr()
+    assert res.out
+    assert not res.err
+
+
+def test_run_snappy_pull_raw_nothing(capsys):
+    """Test ``cubi-tk snappy pull-raw-data``"""
+    parser, _subparsers = setup_argparse()
+
+    with pytest.raises(SystemExit) as e:
+        parser.parse_args(["snappy", "pull-raw-data"])
+
+    assert e.value.code == 2
+
+    res = capsys.readouterr()
+    assert not res.out
+    assert res.err
+
+
+def test_pull_raw_data_filter_irods_collection_fastq(
+    pull_raw_data, remote_files_fastq, remote_files_all
+):
+    """Tests PullRawDataCommand.filter_irods_collection() - FASTQ files"""
+    # Define input
+    absent_sample_list = ["P098", "P099"]
+    samples_list = ["P001", "P002"]
+    file_type = "fastq"
+
+    # Call with samples id as identifiers
+    actual = pull_raw_data.filter_irods_collection(
+        identifiers=samples_list, remote_files_dict=remote_files_all, file_type=file_type
+    )
+    assert actual == remote_files_fastq
+
+    # Sanity check - should return empty dictionary, samples aren't present
+    actual = pull_raw_data.filter_irods_collection(
+        identifiers=absent_sample_list, remote_files_dict=remote_files_fastq, file_type=file_type
+    )
+    assert len(actual) == 0
+
+
+def test_pull_raw_data_get_library_to_irods_dict(pull_raw_data, remote_files_fastq):
+    """Tests PullRawDataCommand.get_library_to_irods_dict()"""
+    samples_list = ["P001", "P002"]
+    actual = pull_raw_data.get_library_to_irods_dict(
+        identifiers=samples_list, remote_files_dict=remote_files_fastq
+    )
+    for id_ in samples_list:
+        assert all([str(irods.file_name).startswith(id_) for irods in actual.get(id_)])
+
+
+def test_pull_raw_data_pair_ipath_with_folder_name(pull_raw_data, library_to_irods_dict):
+    """Tests PullRawDataCommand.pair_ipath_with_folder_name()"""
+    # Define input
+    out_dir = "out_dir"
+    assay_uuid = "99999999-aaa-bbbb-cccc-99999999"
+    wrong_assay_uuid = "11111111-aaa-bbbb-cccc-11111111"
+    identifiers_tup = [("P00{i}".format(i=i), "P00{i}".format(i=i)) for i in (1, 2)]
+
+    # Define expected
+    irods_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P00{i}-N1-DNA1-WES1/1999-09-09/raw_data/"
+        "P00{i}_R{r}_001.{ext}"
+    )
+    full_out_dir = "out_dir/P00{i}/P00{i}-N1-DNA1-WES1/1999-09-09/raw_data/P00{i}_R{r}_001.{ext}"
+    irods_files_list = [
+        irods_path.format(i=i, r=r, ext=ext)
+        for i in (1, 2)
+        for r in (1, 2)
+        for ext in ("fastq.gz", "fastq.gz.md5")
+    ]
+    correct_uuid_output_dir_list = [
+        full_out_dir.format(i=i, r=r, ext=ext)
+        for i in (1, 2)
+        for r in (1, 2)
+        for ext in ("fastq.gz", "fastq.gz.md5")
+    ]
+    wrong_uuid_output_dir_list = [
+        "out_dir/P00{i}/P00{i}_R{r}_001.{ext}".format(i=i, r=r, ext=ext)
+        for i in (1, 2)
+        for r in (1, 2)
+        for ext in ("fastq.gz", "fastq.gz.md5")
+    ]
+    correct_uuid_expected = []
+    for _irods_path, _out_path in zip(irods_files_list, correct_uuid_output_dir_list):
+        correct_uuid_expected.append((_irods_path, _out_path))
+    wrong_uuid_expected = []
+    for _irods_path, _out_path in zip(irods_files_list, wrong_uuid_output_dir_list):
+        wrong_uuid_expected.append((_irods_path, _out_path))
+
+    # Test with correct assay UUID - directory structure same as in SODAR
+    actual = pull_raw_data.pair_ipath_with_outdir(
+        library_to_irods_dict=library_to_irods_dict,
+        identifiers_tuples=identifiers_tup,
+        output_dir=out_dir,
+        assay_uuid=assay_uuid,
+    )
+    assert sorted(actual) == sorted(correct_uuid_expected)
+
+    # Test with wrong assay UUID - all files copied to root of output directory
+    actual = pull_raw_data.pair_ipath_with_outdir(
+        library_to_irods_dict=library_to_irods_dict,
+        identifiers_tuples=identifiers_tup,
+        output_dir=out_dir,
+        assay_uuid=wrong_assay_uuid,
+    )
+    assert sorted(actual) == sorted(wrong_uuid_expected)
+
+
+def test_pull_raw_data_pair_ipath_with_folder_name_empty(pull_raw_data):
+    """Tests PullRawDataCommand.pair_ipath_with_folder_name() - no files"""
+    # Define input
+    out_dir = "out_dir"
+    assay_uuid = "99999999-aaa-bbbb-cccc-99999999"
+    identifiers_tup = [("P00{i}".format(i=i), "P00{i}".format(i=i)) for i in (1, 2)]
+    # Test with correct assay UUID
+    actual = pull_raw_data.pair_ipath_with_outdir(
+        library_to_irods_dict={},
+        identifiers_tuples=identifiers_tup,
+        output_dir=out_dir,
+        assay_uuid=assay_uuid,
+    )
+    assert len(actual) == 0


### PR DESCRIPTION
closes #29 , closes #113 

**Changes**
* Restrict `snappy pull-raw-data` to FASTQ files. Default behavior: looks for FASTQ file names that contain the sample identifier. Otherwise, it looks for path in SODAR that contain the library names (_e.g._, 'P001-N1-DNA1-WGS1').
* Repurposed old `pull-raw-data` as `pull-all-data`. As the name suggests it will download all data associated with a sample from SODAR.