### PR TITLE
`snappy pull-processed-data`: default is to only retrieve latest version of file

### DIFF
--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -250,7 +250,7 @@ class PullProcessedDataCommand(PullDataCommon):
         :type assay_uuid: str
 
         :param retrieve_all: Flag indicates if all versions of the files should be downloaded (True)
-        or just the latest (False).
+        or just the latest (False). Default: False.
         :type retrieve_all: bool
 
         :return: Return list of tuples (iRODS path [str], local output directory [str]).

--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -102,7 +102,20 @@ class PullProcessedDataCommand(PullDataCommon):
             help=f"File extensions to be retrieved. Valid options: {VALID_FILE_TYPES}",
         )
         parser.add_argument(
-            "--overwrite", default=False, action="store_true", help="Allow overwriting of local files."
+            "--download-all-versions",
+            default=False,
+            action="store_true",
+            help=(
+                "By default only the latest version of a file will be download. For instance, if a was uploaded "
+                "two times, in '2022-01-31' and '2022-02-28', only the latest is downloaded. If this flag is "
+                "present, both versions will be downloaded."
+            ),
+        )
+        parser.add_argument(
+            "--overwrite",
+            default=False,
+            action="store_true",
+            help="Allow overwriting of local files.",
         )
         parser.add_argument(
             "--assay-uuid",
@@ -212,16 +225,18 @@ class PullProcessedDataCommand(PullDataCommon):
             remote_files_dict=filtered_remote_files_dict,
             output_dir=self.args.output_directory,
             assay_uuid=self.args.assay_uuid or assay_uuid,
+            retrieve_all=self.args.download_all_versions,
         )
 
         # Retrieve files from iRODS
-        self.get_irods_files(irods_local_path_pairs=path_pair_list, force_overwrite=self.args.overwrite)
+        self.get_irods_files(
+            irods_local_path_pairs=path_pair_list, force_overwrite=self.args.overwrite
+        )
 
         logger.info("All done. Have a nice day!")
         return 0
 
-    @staticmethod
-    def pair_ipath_with_outdir(remote_files_dict, output_dir, assay_uuid):
+    def pair_ipath_with_outdir(self, remote_files_dict, output_dir, assay_uuid, retrieve_all=False):
         """Pair iRODS path with local output directory
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
@@ -234,12 +249,22 @@ class PullProcessedDataCommand(PullDataCommon):
         :param assay_uuid: Assay UUID - used as a hack to get the directory structure in SODAR.
         :type assay_uuid: str
 
+        :param retrieve_all: Flag indicates if all versions of the files should be downloaded (True)
+        or just the latest (False).
+        :type retrieve_all: bool
+
         :return: Return list of tuples (iRODS path [str], local output directory [str]).
         """
         # Initiate output
         output_list = []
         # Iterate over iRODS objects
         for irods_obj_list in remote_files_dict.values():
+
+            # Retrieve only latest, test if list is empty
+            if irods_obj_list and not retrieve_all:
+                irods_obj_list = [self.sort_irods_object_by_date_in_path(irods_obj_list)[0]]
+
+            # Iterate over iRODS object list, by default list contain only latest
             for irods_obj in irods_obj_list:
                 # Keeps iRODS directory structure if assay UUID is provided.
                 # Assumption is that SODAR directories follow the logic below:

--- a/tests/test_snappy_pull_data_common.py
+++ b/tests/test_snappy_pull_data_common.py
@@ -1,0 +1,124 @@
+"""Tests for ``cubi_tk.snappy.pull_data_common``.
+"""
+
+import pytest
+
+from cubi_tk.snappy.pull_data_common import PullDataCommon
+from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+
+# Empty file MD5 checksum
+FILE_MD5SUM = "d41d8cd98f00b204e9800998ecf8427e"
+
+# Arbitrary replicas MD5 checksum value
+REPLICAS_MD5SUM = [FILE_MD5SUM] * 3
+
+
+@pytest.fixture
+def irods_objects_list():
+    """Returns list of iRODS objects for VCF file with three different dates. Format: '%Y-%m-%d'."""
+    p0001_sodar_path = "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P001-N1-DNA1-WES1/%s"
+    return [
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path % '1999-09-09'}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path % '2038-01-19'}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path % '2000-01-01'}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+    ]
+
+
+@pytest.fixture
+def irods_objects_list_format_mixed():
+    """Returns list of iRODS objects for VCF file with three different dates. Multiple date formats."""
+    p0001_sodar_path = "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P001-N1-DNA1-WES1/%s"
+    return [
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path % '1999-09-09'}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path % '2038_01_19'}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path % '20000101'}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+    ]
+
+
+@pytest.fixture
+def irods_objects_list_missing_date():
+    """Returns list of iRODS objects for VCF file with three different dates."""
+    p0001_sodar_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P001-N1-DNA1-WES1/NO_DATE"
+    )
+    return [
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+        IrodsDataObject(
+            file_name="bwa.P001-N1-DNA1-WES1.vcf.gz",
+            irods_path=f"{p0001_sodar_path}/variant_calling/bwa.P001-N1-DNA1-WES1.vcf.gz",
+            file_md5sum=FILE_MD5SUM,
+            replicas_md5sum=REPLICAS_MD5SUM,
+        ),
+    ]
+
+
+def test_pull_data_common_sort_irods_object_by_date_in_path(irods_objects_list):
+    """Tests PullDataCommon.sort_irods_object_by_date_in_path() - format '%Y-%m-%d'"""
+    raw_data_class = PullDataCommon()
+    expected = ("2038-01-19", "2000-01-01", "1999-09-09")
+    actual = raw_data_class.sort_irods_object_by_date_in_path(irods_obj_list=irods_objects_list)
+    for count, irods_obj in enumerate(actual):
+        assert expected[count] in irods_obj.irods_path
+
+
+def test_pull_data_common_sort_irods_object_by_date_in_path_mixed(irods_objects_list_format_mixed):
+    """Tests PullDataCommon.sort_irods_object_by_date_in_path() - mixed dates formats"""
+    raw_data_class = PullDataCommon()
+    expected = ("2038_01_19", "20000101", "1999-09-09")
+    actual = raw_data_class.sort_irods_object_by_date_in_path(
+        irods_obj_list=irods_objects_list_format_mixed
+    )
+    for count, irods_obj in enumerate(actual):
+        assert expected[count] in irods_obj.irods_path
+
+
+def test_pull_data_common_sort_irods_object_by_date_in_path_missing_date(
+    irods_objects_list_missing_date
+):
+    """Tests PullDataCommon.sort_irods_object_by_date_in_path() - missing date in path"""
+    raw_data_class = PullDataCommon()
+    with pytest.raises(ValueError):
+        raw_data_class.sort_irods_object_by_date_in_path(
+            irods_obj_list=irods_objects_list_missing_date
+        )

--- a/tests/test_snappy_pull_processed_data.py
+++ b/tests/test_snappy_pull_processed_data.py
@@ -22,44 +22,64 @@ def pull_processed_data():
 @pytest.fixture
 def remote_files_bam():
     """Returns iRODS collection example for BAM files and two samples, P001 and P002"""
-    p0001_sodar_path = (
-        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P001-N1-DNA1-WES1/1999-09-09"
-    )
-    p0002_sodar_path = (
-        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P002-N1-DNA1-WES1/1999-09-09"
-    )
+    p0001_sodar_path = "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P001-N1-DNA1-WES1/%s"
+    p0002_sodar_path = "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P002-N1-DNA1-WES1/%s"
     return {
         "bwa.P001-N1-DNA1-WES1.bam": [
             IrodsDataObject(
                 file_name="bwa.P001-N1-DNA1-WES1.bam",
-                irods_path=f"{p0001_sodar_path}/ngs_mapping/bwa.P001-N1-DNA1-WES1.bam",
+                irods_path=f"{p0001_sodar_path % '1975-01-04'}/ngs_mapping/bwa.P001-N1-DNA1-WES1.bam",
                 file_md5sum=FILE_MD5SUM,
                 replicas_md5sum=REPLICAS_MD5SUM,
-            )
+            ),
+            IrodsDataObject(
+                file_name="bwa.P001-N1-DNA1-WES1.bam",
+                irods_path=f"{p0001_sodar_path % '1999-09-09'}/ngs_mapping/bwa.P001-N1-DNA1-WES1.bam",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            ),
         ],
         "bwa.P001-N1-DNA1-WES1.bam.bai": [
             IrodsDataObject(
                 file_name="bwa.P001-N1-DNA1-WES1.bam.bai",
-                irods_path=f"{p0001_sodar_path}/ngs_mapping/bwa.P001-N1-DNA1-WES1.bam.bai",
+                irods_path=f"{p0001_sodar_path % '1975-01-04'}/ngs_mapping/bwa.P001-N1-DNA1-WES1.bam.bai",
                 file_md5sum=FILE_MD5SUM,
                 replicas_md5sum=REPLICAS_MD5SUM,
-            )
+            ),
+            IrodsDataObject(
+                file_name="bwa.P001-N1-DNA1-WES1.bam.bai",
+                irods_path=f"{p0001_sodar_path % '1999-09-09'}/ngs_mapping/bwa.P001-N1-DNA1-WES1.bam.bai",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            ),
         ],
         "bwa.P002-N1-DNA1-WES1.bam": [
             IrodsDataObject(
                 file_name="bwa.P002-N1-DNA1-WES1.bam",
-                irods_path=f"{p0002_sodar_path}/ngs_mapping/bwa.P002-N1-DNA1-WES1.bam",
+                irods_path=f"{p0002_sodar_path % '1999-09-09'}/ngs_mapping/bwa.P002-N1-DNA1-WES1.bam",
                 file_md5sum=FILE_MD5SUM,
                 replicas_md5sum=REPLICAS_MD5SUM,
-            )
+            ),
+            IrodsDataObject(
+                file_name="bwa.P002-N1-DNA1-WES1.bam",
+                irods_path=f"{p0002_sodar_path % '1975-01-04'}/ngs_mapping/bwa.P002-N1-DNA1-WES1.bam",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            ),
         ],
         "bwa.P002-N1-DNA1-WES1.bam.bai": [
             IrodsDataObject(
                 file_name="bwa.P002-N1-DNA1-WES1.bam.bai",
-                irods_path=f"{p0002_sodar_path}/ngs_mapping/bwa.P002-N1-DNA1-WES1.bam.bai",
+                irods_path=f"{p0002_sodar_path % '1999-09-09'}/ngs_mapping/bwa.P002-N1-DNA1-WES1.bam.bai",
                 file_md5sum=FILE_MD5SUM,
                 replicas_md5sum=REPLICAS_MD5SUM,
-            )
+            ),
+            IrodsDataObject(
+                file_name="bwa.P002-N1-DNA1-WES1.bam.bai",
+                irods_path=f"{p0002_sodar_path % '1975-01-04'}/ngs_mapping/bwa.P002-N1-DNA1-WES1.bam.bai",
+                file_md5sum=FILE_MD5SUM,
+                replicas_md5sum=REPLICAS_MD5SUM,
+            ),
         ],
     }
 
@@ -492,6 +512,46 @@ def test_pull_processed_data_pair_ipath_with_outdir_bam(pull_processed_data, rem
         remote_files_dict=remote_files_bam, output_dir=out_dir, assay_uuid=wrong_assay_uuid
     )
     assert sorted(actual) == sorted(wrong_uuid_expected)
+
+
+def test_pull_processed_data_pair_ipath_with_outdir_bam_retrieve_all(
+    pull_processed_data, remote_files_bam
+):
+    """Tests PullProcessedDataCommand.pull_processed_data - all versions of BAM files."""
+    # Define input
+    out_dir = "out_dir"
+    assay_uuid = "99999999-aaa-bbbb-cccc-99999999"
+
+    # Define expected
+    irods_path = (
+        "/sodar_path/.../assay_99999999-aaa-bbbb-cccc-99999999/P00{i}-N1-DNA1-WES1/{date}/ngs_mapping/"
+        "bwa.P00{i}-N1-DNA1-WES1.{ext}"
+    )
+    full_out_dir = "out_dir/P00{i}-N1-DNA1-WES1/{date}/ngs_mapping/bwa.P00{i}-N1-DNA1-WES1.{ext}"
+    irods_files_list = [
+        irods_path.format(i=i, date=date, ext=ext)
+        for i in (1, 2)
+        for date in ("1999-09-09", "1975-01-04")
+        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+    ]
+    correct_uuid_output_dir_list = [
+        full_out_dir.format(i=i, date=date, ext=ext)
+        for i in (1, 2)
+        for date in ("1999-09-09", "1975-01-04")
+        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+    ]
+    correct_uuid_expected = []
+    for _irods_path, _out_path in zip(irods_files_list, correct_uuid_output_dir_list):
+        correct_uuid_expected.append((_irods_path, _out_path))
+
+    # Test with correct assay UUID - directory structure same as in SODAR
+    actual = pull_processed_data.pair_ipath_with_outdir(
+        remote_files_dict=remote_files_bam,
+        output_dir=out_dir,
+        assay_uuid=assay_uuid,
+        retrieve_all=True,
+    )
+    assert sorted(actual) == sorted(correct_uuid_expected)
 
 
 def test_pull_processed_data_pair_ipath_with_outdir_vcf(pull_processed_data, remote_files_vcf):


### PR DESCRIPTION
closes #125

**Changes**
* Default behavior is to only retrieve latest version of a given file.
* New flag `--download-all-versions` to indicate that all versions of a file should be retrieved.