### PR TITLE
Adjust to `snappy` export external data workflows (#129, #132)

### DIFF
--- a/cubi_tk/snappy/common.py
+++ b/cubi_tk/snappy/common.py
@@ -15,15 +15,18 @@ DEPENDENCIES: typing.Dict[str, typing.Tuple[str, ...]] = {
     "roh_calling": ("variant_calling",),
     "variant_calling": ("ngs_mapping",),
     "variant_export": ("variant_calling",),
+    "variant_export_external": (),
     "targeted_seq_cnv_calling": ("ngs_mapping",),
     "targeted_seq_cnv_annotation": ("targeted_seq_cnv_calling",),
     "targeted_seq_cnv_export": ("targeted_seq_cnv_annotation",),
     "wgs_sv_calling": ("ngs_mapping",),
     "wgs_sv_annotation": ("wgs_sv_calling",),
     "wgs_sv_export": ("wgs_sv_annotation",),
+    "wgs_sv_export_external": (),
     "wgs_cnv_calling": ("ngs_mapping", "variant_calling"),
     "wgs_cnv_annotation": ("wgs_cnv_calling",),
     "wgs_cnv_export": ("wgs_cnv_annotation",),
+    "wgs_cnv_export_external": (),
 }
 
 

--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -120,7 +120,7 @@ class SnappyVarFishUploadCommand:
             action="store_true",
             help=(
                 "Flag to indicate that data was externally generated. Search for files will not filter based "
-                "on common internally tool combinations, example: 'bwa.delly2' or 'bwa'."
+                "on common internally tool combinations, example: 'bwa.delly2' or 'bwa.gatk_hc'."
             ),
         )
         parser.add_argument(

--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -226,14 +226,15 @@ class SnappyVarFishUploadCommand:
                 continue
 
             # Search for files of interest.
+            prefix_text = f" and prefixes\n    {PREFIXES}"
+            if self.args.external_data:
+                prefix_text = ""
             logger.debug(
-                "\nSearching in\n    %s\nfor library\n    %s\n"
-                "steps\n    %s\nand extensions\n    %s\n and prefixes\n    %s",
-                self.args.base_path,
-                library,
-                self.args.steps,
-                EXTENSIONS,
-                PREFIXES,
+                f"\nSearching in\n    {self.args.base_path}\n"
+                f"for library\n    {library}\n"
+                f"steps\n   {self.args.steps}\n"
+                f"and extensions\n    {EXTENSIONS}\n"
+                f"{prefix_text}"
             )
             found: typing.Dict[str, str] = {}
             for step in self.args.steps:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,7 +51,7 @@ argcomplete
 pyyaml
 
 # VarFish REST API client.
-varfish-cli
+varfish-cli >=0.3.5
 
 # Compact, round-tripable configuration format.
 toml


### PR DESCRIPTION
closes #129, closes #132 

**Changes**
* Included `*_export_external` workflows in `varfish_upload` default.
* Added new argument `--external-data`, if present it won't filter files based on common `snappy` tool combination.
* Included `*_export_external` workflows in kickoff common dependencies .

Note: only merge after https://github.com/bihealth/snappy-pipeline/pull/216 is complete.