### PR TITLE
feat: SODAR ingest command based on irods-pythonclient

### DIFF
--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -110,9 +110,6 @@ class iRODSTransfer:
                         self.session.cleanup()
                 t.clear()
 
-    def get(self):
-        pass
-
     def chksum(self):
         common_prefix = os.path.commonprefix(self.destinations)
         for job in self.jobs:

--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -83,7 +83,7 @@ def init_irods(irods_env_path: Path, ask: bool = False) -> iRODSSession:
     if ask and input("Save iRODS session for passwordless operation? [y/N] ").lower().startswith(
         "y"
     ):
-        save_irods_token(session)
+        save_irods_token(session)  # pragma: no cover
     elif not ask:
         save_irods_token(session)
 
@@ -101,7 +101,7 @@ def save_irods_token(session: iRODSSession, irods_env_path=None):
 
     try:
         token = session.pam_pw_negotiated
-    except CAT_INVALID_AUTHENTICATION:
+    except CAT_INVALID_AUTHENTICATION:  # pragma: no cover
         raise
 
     if isinstance(token, list) and token:

--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -1,0 +1,106 @@
+import getpass
+import os.path
+import sys
+from typing import Tuple
+
+import attr
+from irods.session import iRODSSession
+from logzero import logger
+from tqdm import tqdm
+
+# TODO: move this class to common.py?
+# from .snappy.itransfer_common import TransferJob
+
+
+@attr.s(frozen=True, auto_attribs=True)
+class TransferJob:
+    """Encodes a transfer job from the local file system to the remote iRODS collection."""
+
+    #: Source path.
+    path_src: str
+
+    #: Destination path.
+    path_dest: str
+
+    #: Number of bytes to transfer.
+    bytes: int
+
+
+def get_irods_error(e: Exception):
+    """Return logger friendly iRODS exception."""
+    es = str(e)
+    return es if es and es != "None" else e.__class__.__name__
+
+
+def init_irods(irods_env_path: os.PathLike) -> iRODSSession:
+    """Connect to iRODS."""
+    irods_auth_path = irods_env_path.parent.joinpath(".irodsA")
+    if irods_auth_path.exists():
+        try:
+            session = iRODSSession(irods_env_file=irods_env_path)
+            session.server_version  # check for outdated .irodsA file
+        except Exception as e:
+            logger.error(f"iRODS connection failed: {get_irods_error(e)}")
+            logger.error("Are you logged in? try 'iinit'")
+            sys.exit(1)
+        finally:
+            session.cleanup()
+    else:
+        # Query user for password.
+        logger.info("iRODS authentication file not found.")
+        password = getpass.getpass(prompt="Please enter SODAR password:")
+        try:
+            session = iRODSSession(irods_env_file=irods_env_path, password=password)
+            session.server_version  # check for exceptions
+        except Exception as e:
+            logger.error(f"iRODS connection failed: {get_irods_error(e)}")
+            sys.exit(1)
+        finally:
+            session.cleanup()
+
+    return session
+
+
+class iRODSTransfer:
+    """Transfers files to and from iRODS."""
+
+    def __init__(self, session: iRODSSession, jobs: Tuple[TransferJob, ...]):
+        self.session = session
+        self.jobs = jobs
+        self.total_bytes = sum([job.bytes for job in self.jobs])
+        self.destinations = [job.path_dest for job in self.jobs]
+
+    def put(self):
+        # TODO: add more parenthesis after python 3.10
+        with tqdm(
+            total=self.total_bytes, unit="B", unit_scale=True, unit_divisor=1024, position=1
+        ) as t, tqdm(total=0, position=0, bar_format="{desc}", leave=False) as file_log:
+            for job in self.jobs:
+                try:
+                    file_log.set_description_str(f"Current file: {job.path_src}")
+                    self.session.data_objects.put(job.path_src, job.path_dest)
+                    t.update(job.bytes)
+                except Exception as e:
+                    logger.error(f"Problem during transfer of {job.path_src}")
+                    logger.error(get_irods_error(e))
+                    sys.exit(1)
+                finally:
+                    self.session.cleanup()
+            t.clear()
+
+    def get(self):
+        pass
+
+    def chksum(self):
+        common_prefix = os.path.commonprefix(self.destinations)
+        for job in self.jobs:
+            if not job.path_src.endswith(".md5"):
+                print(os.path.relpath(job.path_dest, common_prefix))
+                try:
+                    data_object = self.session.data_objects.get(job.path_dest)
+                    data_object.chksum()
+                except Exception as e:
+                    logger.error("iRODS checksum error.")
+                    logger.error(get_irods_error(e))
+                finally:
+                    self.session.cleanup()

--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -43,7 +43,7 @@ def init_irods(irods_env_path: os.PathLike) -> iRODSSession:
         try:
             session = iRODSSession(irods_env_file=irods_env_path)
             session.server_version  # check for outdated .irodsA file
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             logger.error(f"iRODS connection failed: {get_irods_error(e)}")
             logger.error("Are you logged in? try 'iinit'")
             sys.exit(1)
@@ -56,7 +56,7 @@ def init_irods(irods_env_path: os.PathLike) -> iRODSSession:
         try:
             session = iRODSSession(irods_env_file=irods_env_path, password=password)
             session.server_version  # check for exceptions
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             logger.error(f"iRODS connection failed: {get_irods_error(e)}")
             sys.exit(1)
         finally:
@@ -102,7 +102,7 @@ class iRODSTransfer:
                             job.path_dest + ".md5",
                         )
                         t.update(job.bytes)
-                    except Exception as e:
+                    except Exception as e:  # pragma: no cover
                         logger.error(f"Problem during transfer of {job.path_src}")
                         logger.error(get_irods_error(e))
                         sys.exit(1)
@@ -121,7 +121,7 @@ class iRODSTransfer:
                 try:
                     data_object = self.session.data_objects.get(job.path_dest)
                     data_object.chksum()
-                except Exception as e:
+                except Exception as e:  # pragma: no cover
                     logger.error("iRODS checksum error.")
                     logger.error(get_irods_error(e))
                 finally:

--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -2,7 +2,6 @@ import getpass
 import os.path
 from pathlib import Path
 import sys
-import tempfile
 from typing import Set
 
 import attr
@@ -30,9 +29,6 @@ class TransferJob:
 
     #: Number of bytes to transfer.
     bytes: int
-
-    #: MD5 hashsum of file.
-    md5: str
 
 
 def get_irods_error(e: Exception):
@@ -125,39 +121,27 @@ class iRODSTransfer:
         self.destinations = [job.path_dest for job in self.jobs]
 
     def put(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Double tqdm for currently transferred file info
-            # TODO: add more parenthesis after python 3.10
-            with tqdm(
-                total=self.total_bytes,
-                unit="B",
-                unit_scale=True,
-                unit_divisor=1024,
-                position=1,
-            ) as t, tqdm(total=0, position=0, bar_format="{desc}", leave=False) as file_log:
-                for job in self.jobs:
-                    file_log.set_description_str(f"Current file: {job.path_src}")
-                    job_name = Path(job.path_src).name
-
-                    # create temporary md5 files
-                    hashpath = Path(temp_dir).joinpath(job_name + ".md5")
-                    with hashpath.open("w", encoding="utf-8") as tmp:
-                        tmp.write(f"{job.md5}  {job_name}")
-
-                    try:
-                        self.session.data_objects.put(job.path_src, job.path_dest)
-                        self.session.data_objects.put(
-                            hashpath,
-                            job.path_dest + ".md5",
-                        )
-                        t.update(job.bytes)
-                    except Exception as e:  # pragma: no cover
-                        logger.error(f"Problem during transfer of {job.path_src}")
-                        logger.error(get_irods_error(e))
-                        sys.exit(1)
-                    finally:
-                        self.session.cleanup()
-                t.clear()
+        # Double tqdm for currently transferred file info
+        # TODO: add more parenthesis after python 3.10
+        with tqdm(
+            total=self.total_bytes,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+            position=1,
+        ) as t, tqdm(total=0, position=0, bar_format="{desc}", leave=False) as file_log:
+            for job in self.jobs:
+                file_log.set_description_str(f"Current file: {job.path_src}")
+                try:
+                    self.session.data_objects.put(job.path_src, job.path_dest)
+                    t.update(job.bytes)
+                except Exception as e:  # pragma: no cover
+                    logger.error(f"Problem during transfer of {job.path_src}")
+                    logger.error(get_irods_error(e))
+                    sys.exit(1)
+                finally:
+                    self.session.cleanup()
+            t.clear()
 
     def chksum(self):
         common_prefix = os.path.commonpath(self.destinations)

--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -110,7 +110,13 @@ def save_irods_token(session: iRODSSession, irods_env_path=None):
 
 
 class iRODSTransfer:
-    """Transfers files to and from iRODS."""
+    """
+    Transfer files to iRODS.
+
+    Attributes:
+    session -- initialised iRODSSession
+    jobs -- a tuple of TransferJob objects
+    """
 
     def __init__(self, session: iRODSSession, jobs: Tuple[TransferJob, ...]):
         self.session = session

--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -44,6 +44,7 @@ def init_irods(irods_env_path: Path, ask: bool = False) -> iRODSSession:
         try:
             session = iRODSSession(irods_env_file=irods_env_path)
             session.server_version  # check for outdated .irodsA file
+            session.connection_timeout = 300
             return session
         except Exception as e:  # pragma: no cover
             logger.error(f"iRODS connection failed: {get_irods_error(e)}")

--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -163,7 +163,7 @@ class iRODSTransfer:
                     data_object = self.session.data_objects.get(job.path_dest)
                     data_object.chksum()
                 except Exception as e:  # pragma: no cover
-                    logger.error("iRODS checksum error.")
+                    logger.error("Problem during iRODS checksumming.")
                     logger.error(get_irods_error(e))
                 finally:
                     self.session.cleanup()

--- a/cubi_tk/irods_utils.py
+++ b/cubi_tk/irods_utils.py
@@ -9,11 +9,13 @@ import attr
 from irods.exception import CAT_INVALID_AUTHENTICATION, PAM_AUTH_PASSWORD_FAILED
 from irods.password_obfuscation import encode
 from irods.session import iRODSSession
+import logzero
 from logzero import logger
 from tqdm import tqdm
 
-# TODO: move this class to common.py?
-# from .snappy.itransfer_common import TransferJob
+# no-frills logger
+formatter = logzero.LogFormatter(fmt="%(message)s")
+output_logger = logzero.setup_logger(formatter=formatter)
 
 
 @attr.s(frozen=True, auto_attribs=True)
@@ -156,7 +158,7 @@ class iRODSTransfer:
         common_prefix = os.path.commonprefix(self.destinations)
         for job in self.jobs:
             if not job.path_src.endswith(".md5"):
-                print(os.path.relpath(job.path_dest, common_prefix))
+                output_logger.info(os.path.relpath(job.path_dest, common_prefix))
                 try:
                     data_object = self.session.data_objects.get(job.path_dest)
                     data_object.chksum()

--- a/cubi_tk/sodar/__init__.py
+++ b/cubi_tk/sodar/__init__.py
@@ -56,8 +56,8 @@ from ..common import run_nocmd
 from .add_ped import setup_argparse as setup_argparse_add_ped
 from .check_remote import setup_argparse as setup_argparse_check_remote
 from .download_sheet import setup_argparse as setup_argparse_download_sheet
-from .ingest_fastq import setup_argparse as setup_argparse_ingest_fastq
 from .ingest import setup_argparse as setup_argparse_ingest
+from .ingest_fastq import setup_argparse as setup_argparse_ingest_fastq
 from .lz_create import setup_argparse as setup_argparse_lz_create
 from .lz_list import setup_argparse as setup_argparse_lz_list
 from .lz_move import setup_argparse as setup_argparse_lz_move

--- a/cubi_tk/sodar/__init__.py
+++ b/cubi_tk/sodar/__init__.py
@@ -37,6 +37,9 @@ Sub Commands
     Upload external files to SODAR
     (defaults for fastq files).
 
+``ingest``
+    Upload arbitrary files to SODAR
+
 ``check-remote``
     Check if or which local files with md5 sums are already deposited in iRODs/Sodar
 
@@ -54,6 +57,7 @@ from .add_ped import setup_argparse as setup_argparse_add_ped
 from .check_remote import setup_argparse as setup_argparse_check_remote
 from .download_sheet import setup_argparse as setup_argparse_download_sheet
 from .ingest_fastq import setup_argparse as setup_argparse_ingest_fastq
+from .ingest import setup_argparse as setup_argparse_ingest
 from .lz_create import setup_argparse as setup_argparse_lz_create
 from .lz_list import setup_argparse as setup_argparse_lz_list
 from .lz_move import setup_argparse as setup_argparse_lz_move
@@ -87,6 +91,7 @@ def setup_argparse(parser: argparse.ArgumentParser) -> None:
             "ingest-fastq", help="Upload external files to SODAR (defaults for fastq)"
         )
     )
+    setup_argparse_ingest(subparsers.add_parser("ingest", help="Upload arbitrary files to SODAR"))
     setup_argparse_check_remote(
         subparsers.add_parser(
             "check-remote", help="Compare local files with md5 sum against SODAR/iRODS"

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -241,6 +241,7 @@ class SodarIngest:
             logger.info("Nothing to do. Quitting.")
             sys.exit(0)
 
+        jobs = sorted(jobs, key=lambda x: x.path_src)
         itransfer = iRODSTransfer(irods_session, jobs)
         total_bytes = itransfer.total_bytes
         logger.info("Planning to transfer the following files:")

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -47,11 +47,15 @@ class SodarIngest:
 
         # Get SODAR API info
         toml_config = load_toml_config(Config())
-
-        if not self.args.sodar_url:
-            self.args.sodar_url = toml_config.get("global", {}).get("sodar_server_url")
+        if toml_config:
+            config_url = toml_config.get("global", {}).get("sodar_server_url")
+            if self.args.sodar_url == "https://sodar.bihealth.org/" and config_url:
+                self.args.sodar_url = config_url
+            if not self.args.sodar_api_token:
+                self.args.sodar_api_token = toml_config.get("global", {}).get("sodar_api_token")
         if not self.args.sodar_api_token:
-            self.args.sodar_api_token = toml_config.get("global", {}).get("sodar_api_token")
+            logger.error("SODAR API token missing.")
+            sys.exit(1)
 
     @classmethod
     def setup_argparse(cls, parser: argparse.ArgumentParser) -> None:
@@ -91,7 +95,9 @@ class SodarIngest:
             help="Don't ask for permission.",
         )
         parser.add_argument(
-            "--collection", type=str, help="Target iRODS collection. Skips manual selection input."
+            "--collection",
+            type=str,
+            help="Target iRODS collection. Skips manual selection input.",
         )
         parser.add_argument(
             "sources", help="One or multiple files/directories to ingest.", nargs="+"

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -14,6 +14,9 @@ from cubi_tk.irods_utils import TransferJob, get_irods_error, init_irods, iRODST
 
 from ..common import compute_md5_checksum, is_uuid, load_toml_config, sizeof_fmt
 
+# for testing
+logger.propagate = True
+
 
 @attr.s(frozen=True, auto_attribs=True)
 class Config:
@@ -233,12 +236,12 @@ class SodarIngest:
 
         for src in source_paths:
             try:
-                abspath = src.resolve()
+                abspath = src.resolve(strict=True)
             except FileNotFoundError:
                 logger.warning(f"File not found: {src.name}")
                 continue
             except RuntimeError:
-                logger.warning(f"Infinite loop: {src.name}")
+                logger.warning(f"Symlink loop: {src.name}")
                 continue
 
             if src.is_dir():

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -7,6 +7,7 @@ import sys
 import typing
 
 import attr
+import logzero
 from logzero import logger
 from sodar_cli import api
 
@@ -16,6 +17,10 @@ from ..common import compute_md5_checksum, is_uuid, load_toml_config, sizeof_fmt
 
 # for testing
 logger.propagate = True
+
+# no-frills logger
+formatter = logzero.LogFormatter(fmt="%(message)s")
+output_logger = logzero.setup_logger(formatter=formatter)
 
 
 @attr.s(frozen=True, auto_attribs=True)
@@ -184,7 +189,7 @@ class SodarIngest:
 
             logger.info("Planning to create the following sub-collections:")
             for d in dirs:
-                print(f"{self.target_coll}/{str(d)}")
+                output_logger.info(f"{self.target_coll}/{str(d)}")
             if not self.args.yes:
                 if not input("Is this OK? [y/N] ").lower().startswith("y"):
                     logger.info("Aborting at your request.")
@@ -210,10 +215,10 @@ class SodarIngest:
         total_bytes = itransfer.total_bytes
         logger.info("Planning to transfer the following files:")
         for job in jobs:
-            print(job.path_src)
+            output_logger.info(job.path_src)
         logger.info(f"With a total size of {sizeof_fmt(total_bytes)}")
         logger.info("Into this iRODS collection:")
-        print(f"{self.lz_irods_path}/{self.target_coll}/")
+        output_logger.info(f"{self.lz_irods_path}/{self.target_coll}/")
 
         if not self.args.yes:
             if not input("Is this OK? [y/N] ").lower().startswith("y"):

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -108,6 +108,7 @@ class SodarIngest:
         )
         parser.add_argument(
             "-y",
+            "--yes",
             default=False,
             action="store_true",
             help="Don't ask for permission prior to transfer.",
@@ -218,7 +219,7 @@ class SodarIngest:
             logger.info("Planning to create the following sub-collections:")
             for d in dirs:
                 print(f"{self.target_coll}/{str(d)}")
-            if not self.args.y:
+            if not self.args.yes:
                 if not input("Is this OK? [y/N] ").lower().startswith("y"):
                     logger.error("Aborting at your request.")
                     sys.exit(0)
@@ -247,7 +248,7 @@ class SodarIngest:
         logger.info("Into this iRODS collection:")
         print(f"{self.lz_irods_path}/{self.target_coll}/")
 
-        if not self.args.y:
+        if not self.args.yes:
             if not input("Is this OK? [y/N] ").lower().startswith("y"):
                 logger.error("Aborting at your request.")
                 sys.exit(0)

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -45,6 +45,14 @@ class SodarIngest:
             logger.error("iRODS environment file is missing.")
             sys.exit(1)
 
+        # Get SODAR API info
+        toml_config = load_toml_config(Config())
+
+        if not self.args.sodar_url:
+            self.args.sodar_url = toml_config.get("global", {}).get("sodar_server_url")
+        if not self.args.sodar_api_token:
+            self.args.sodar_api_token = toml_config.get("global", {}).get("sodar_api_token")
+
     @classmethod
     def setup_argparse(cls, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -99,14 +107,6 @@ class SodarIngest:
 
     def execute(self):
         """Execute ingest."""
-        # Get SODAR API info
-        toml_config = load_toml_config(Config())
-
-        if not self.args.sodar_url:
-            self.args.sodar_url = toml_config.get("global", {}).get("sodar_server_url")
-        if not self.args.sodar_api_token:
-            self.args.sodar_api_token = toml_config.get("global", {}).get("sodar_api_token")
-
         # Retrieve iRODS path if destination is UUID
         if is_uuid(self.args.destination):
             try:
@@ -115,7 +115,7 @@ class SodarIngest:
                     sodar_api_token=self.args.sodar_api_token,
                     landingzone_uuid=self.args.destination,
                 )
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 logger.error("Failed to retrieve landing zone information.")
                 logger.error(e)
                 sys.exit(1)
@@ -128,7 +128,7 @@ class SodarIngest:
                 logger.error("Target landing zone is not ACTIVE.")
                 sys.exit(1)
         else:
-            self.lz_irods_path = self.args.destination
+            self.lz_irods_path = self.args.destination  # pragma: no cover
 
         # Build file list and add missing md5 files
         source_paths = self.build_file_list()
@@ -143,7 +143,7 @@ class SodarIngest:
             coll = irods_session.collections.get(self.lz_irods_path)
             for c in coll.subcollections:
                 collections.append(c.name)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             logger.error(f"Failed to query landing zone collections: {get_irods_error(e)}")
             sys.exit(1)
         finally:
@@ -168,7 +168,7 @@ class SodarIngest:
 
         elif self.args.collection in collections:
             self.target_coll = self.args.collection
-        else:
+        else:  # pragma: no cover
             logger.error("Selected target collection does not exist in landing zone.")
             sys.exit(1)
 
@@ -182,7 +182,7 @@ class SodarIngest:
             for d in dirs:
                 output_logger.info(f"{self.target_coll}/{str(d)}")
             if not self.args.yes:
-                if not input("Is this OK? [y/N] ").lower().startswith("y"):
+                if not input("Is this OK? [y/N] ").lower().startswith("y"):  # pragma: no cover
                     logger.info("Aborting at your request.")
                     sys.exit(0)
 
@@ -190,7 +190,7 @@ class SodarIngest:
                 coll_name = f"{self.lz_irods_path}/{self.target_coll}/{str(d)}"
                 try:
                     irods_session.collections.create(coll_name)
-                except Exception as e:
+                except Exception as e:  # pragma: no cover
                     logger.error("Error creating sub-collection.")
                     logger.error(e)
                     sys.exit(1)
@@ -212,7 +212,7 @@ class SodarIngest:
         output_logger.info(f"{self.lz_irods_path}/{self.target_coll}/")
 
         if not self.args.yes:
-            if not input("Is this OK? [y/N] ").lower().startswith("y"):
+            if not input("Is this OK? [y/N] ").lower().startswith("y"):  # pragma: no cover
                 logger.info("Aborting at your request.")
                 sys.exit(0)
 
@@ -220,7 +220,7 @@ class SodarIngest:
         logger.info("File transfer complete.")
 
         # Compute server-side checksums
-        if self.args.remote_checksums:
+        if self.args.remote_checksums:  # pragma: no cover
             logger.info("Computing server-side checksums.")
             itransfer.chksum()
 

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -85,7 +85,8 @@ class SodarIngest:
             "-e",
             "--exclude",
             nargs="+",
-            type=list,
+            default="",
+            type=str,
             help="Exclude files by defining one or multiple glob-style patterns.",
         )
         parser.add_argument(
@@ -281,9 +282,9 @@ class SodarIngest:
                 logger.warning(f"Symlink loop: {src.name}")
                 continue
 
+            excludes = self.args.exclude
             if src.is_dir():
                 paths = abspath.glob("**/*" if self.args.recursive else "*")
-                excludes = self.args.exclude
                 for p in paths:
                     if excludes and any([p.match(e) for e in excludes]):
                         continue

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -231,7 +231,10 @@ class SodarIngest:
             itransfer.chksum()
 
     def build_file_list(self):
-        """Build list of source files to transfer. iRODS paths are relative to target collection."""
+        """
+        Build list of source files to transfer.
+        iRODS paths are relative to target collection.
+        """
 
         source_paths = [Path(src) for src in self.args.sources]
         output_paths = list()

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -141,7 +141,7 @@ class SodarIngest:
         source_paths = self.build_file_list()
         if len(source_paths) == 0:
             logger.info("Nothing to do. Quitting.")
-            sys.exit(1)
+            sys.exit(0)
 
         # Initiate iRODS session
         irods_session = init_irods(self.irods_env_path, ask=not self.args.yes)
@@ -231,7 +231,7 @@ class SodarIngest:
         # Final go from user & transfer
         if len(jobs) == 0:
             logger.info("Nothing to do. Quitting.")
-            sys.exit(1)
+            sys.exit(0)
 
         itransfer = iRODSTransfer(irods_session, jobs)
         total_bytes = itransfer.total_bytes

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -1,0 +1,366 @@
+"""``cubi-tk sodar ingest``: add arbitrary files to SODAR"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+import getpass
+import typing
+import attr
+
+from irods.session import iRODSSession
+from logzero import logger
+from sodar_cli import api
+from ..common import load_toml_config, is_uuid, compute_md5_checksum, sizeof_fmt
+from ..snappy.itransfer_common import TransferJob
+from tqdm import tqdm
+
+
+@attr.s(frozen=True, auto_attribs=True)
+class Config:
+    """Configuration for the ingest command."""
+
+    config: str = attr.field(default=None)
+    sodar_server_url: str = attr.field(default=None)
+    sodar_api_token: str = attr.field(default=None, repr=lambda value: "***")  # type: ignore
+
+
+class SodarIngest:
+    """Implementation of sodar ingest command."""
+
+    def __init__(self, args):
+        # Command line arguments.
+        self.args = args
+
+        # Path to iRODS environment file
+        self.irods_env_path = Path(Path.home(), ".irods", "irods_environment.json")
+        if not self.irods_env_path.exists():
+            logger.error("iRODS environment file is missing.")
+            sys.exit(1)
+
+        # iRODS environment
+        self.irods_env = None
+
+    def _init_irods(self):
+        """Connect to iRODS."""
+        irods_auth_path = self.irods_env_path.parent.joinpath(".irodsA")
+        if irods_auth_path.exists():
+            try:
+                session = iRODSSession(irods_env_file=self.irods_env_path)
+                session.server_version  # check for outdated .irodsA file
+            except Exception as e:
+                logger.error("iRODS connection failed: %s", self.get_irods_error(e))
+                logger.error("Are you logged in? try 'iinit'")
+                sys.exit(1)
+            finally:
+                session.cleanup()
+        else:
+            # Query user for password.
+            logger.info("iRODS authentication file not found.")
+            password = getpass.getpass(prompt="Please enter SODAR password:")
+            try:
+                session = iRODSSession(irods_env_file=self.irods_env_path, password=password)
+                session.server_version  # check for exceptions
+            except Exception as e:
+                logger.error("iRODS connection failed: %s", self.get_irods_error(e))
+                sys.exit(1)
+            finally:
+                session.cleanup()
+
+        return session
+
+    @classmethod
+    def setup_argparse(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--hidden-cmd", dest="sodar_cmd", default=cls.run, help=argparse.SUPPRESS
+        )
+        group_sodar = parser.add_argument_group("SODAR-related")
+        group_sodar.add_argument(
+            "--sodar-url",
+            default=os.environ.get("SODAR_URL", "https://sodar.bihealth.org/"),
+            help="URL to SODAR, defaults to SODAR_URL environment variable or fallback to https://sodar.bihealth.org/",
+        )
+        group_sodar.add_argument(
+            "--sodar-api-token",
+            default=os.environ.get("SODAR_API_TOKEN", None),
+            help="SODAR API token. Defaults to SODAR_API_TOKEN environment variable.",
+        )
+        parser.add_argument(
+            "-r",
+            "--recursive",
+            default=False,
+            action="store_true",
+            help="Recursively match files in subdirectories. Creates iRODS sub-collections to match directory structure.",
+        )
+        parser.add_argument(
+            "-c",
+            "--checksums",
+            default=False,
+            action="store_true",
+            help="Compute missing md5 checksums for source files.",
+        )
+        parser.add_argument(
+            "-K",
+            "--remote-checksums",
+            default=False,
+            action="store_true",
+            help="Trigger checksum computation on the iRODS side.",
+        )
+        parser.add_argument(
+            "-y",
+            default=False,
+            action="store_true",
+            help="Don't ask for permission prior to transfer.",
+        )
+        parser.add_argument(
+            "--collection", type=str, help="Target iRODS collection. Skips manual selection input."
+        )
+        parser.add_argument(
+            "sources", help="One or multiple files/directories to ingest.", nargs="+"
+        )
+        parser.add_argument("destination", help="UUID or iRODS path of SODAR landing zone.")
+
+    @classmethod
+    def get_irods_error(cls, e: Exception):
+        """Return logger friendly iRODS exception."""
+        es = str(e)
+        return es if es != "None" else e.__class__.__name__
+
+    @classmethod
+    def run(
+        cls, args, _parser: argparse.ArgumentParser, _subparser: argparse.ArgumentParser
+    ) -> typing.Optional[int]:
+        """Entry point into the command."""
+        return cls(args).execute()
+
+    def execute(self):
+        """Execute ingest."""
+        # Get SODAR API info
+        toml_config = load_toml_config(Config())
+
+        if not self.args.sodar_url:
+            self.args.sodar_url = toml_config.get("global", {}).get("sodar_server_url")
+        if not self.args.sodar_api_token:
+            self.args.sodar_api_token = toml_config.get("global", {}).get("sodar_api_token")
+
+        # Retrieve iRODS path if destination is UUID
+        if is_uuid(self.args.destination):
+            try:
+                lz_info = api.landingzone.retrieve(
+                    sodar_url=self.args.sodar_url,
+                    sodar_api_token=self.args.sodar_api_token,
+                    landingzone_uuid=self.args.destination,
+                )
+            except Exception as e:
+                logger.error("Failed to retrieve landing zone information.")
+                logger.error(e)
+                sys.exit(1)
+
+            # TODO: Replace with status_locked check once implemented in sodar_cli
+            if lz_info.status in ["ACTIVE", "FAILED"]:
+                self.lz_irods_path = lz_info.irods_path
+                logger.info(f"Target iRods path: {self.lz_irods_path}")
+            else:
+                logger.info("Target landing zone is not ACTIVE.")
+                sys.exit(1)
+        else:
+            self.lz_irods_path = self.args.destination
+
+        # Build file list and add missing md5 files
+        source_paths = self.build_file_list()
+        source_paths = self.process_md5_sums(source_paths)
+
+        # Initiate iRODS session
+        irods_session = self._init_irods()
+
+        # Query target collection
+        logger.info("Querying landing zone collections…")
+        collections = []
+        try:
+            coll = irods_session.collections.get(self.lz_irods_path)
+            for c in coll.subcollections:
+                collections.append(c.name)
+        except:
+            logger.error("Failed to query landing zone collections.")
+            sys.exit(1)
+        finally:
+            irods_session.cleanup()
+
+        if self.args.collection is None:
+            user_input = ""
+            input_valid = False
+            input_message = "####################\nPlease choose target collection:\n"
+            for index, item in enumerate(collections):
+                input_message += f"{index+1}) {item}\n"
+            input_message += "Select by number: "
+
+            while not input_valid:
+                user_input = input(input_message)
+                if user_input.isdigit():
+                    user_input = int(user_input)
+                    if 0 < user_input < len(collections):
+                        input_valid = True
+
+            self.target_coll = collections[user_input - 1]
+
+        elif self.args.collection in collections:
+            self.target_coll = self.args.collection
+        else:
+            logger.error("Selected target collection does not exist in landing zone.")
+            sys.exit(1)
+
+        # Create sub-collections for folders
+        if self.args.recursive:
+            dirs = sorted(
+                {p["ipath"].parent for p in source_paths if not p["ipath"].parent == Path(".")}
+            )
+
+            logger.info("Planning to create the following sub-collections:")
+            for d in dirs:
+                print(f"{self.target_coll}/{str(d)}")
+            if not self.args.y:
+                if not input("Is this OK? [y/N] ").lower().startswith("y"):
+                    logger.error("Aborting at your request.")
+                    sys.exit(0)
+
+            for d in dirs:
+                coll_name = f"{self.lz_irods_path}/{self.target_coll}/{str(d)}"
+                try:
+                    irods_session.collections.create(coll_name)
+                except Exception as e:
+                    logger.error("Error creating sub-collection.")
+                    logger.error(e)
+                    sys.exit(1)
+                finally:
+                    irods_session.cleanup()
+            logger.info("Sub-collections created.")
+
+        # Build transfer jobs
+        jobs = self.build_jobs(source_paths)
+
+        # Final go from user & transfer
+        total_bytes = sum([job.bytes for job in jobs])
+        logger.info("Planning to transfer the following files:")
+        for job in jobs:
+            print(job.path_src)
+        logger.info(f"With a total size of {sizeof_fmt(total_bytes)}")
+        logger.info("Into this iRODS collection:")
+        print(f"{self.lz_irods_path}/{self.target_coll}/")
+
+        if not self.args.y:
+            if not input("Is this OK? [y/N] ").lower().startswith("y"):
+                logger.error("Aborting at your request.")
+                sys.exit(0)
+        # TODO: add more parenthesis after python 3.10
+        with tqdm(
+            total=total_bytes, unit="B", unit_scale=True, unit_divisor=1024, position=1
+        ) as t, tqdm(total=0, position=0, bar_format="{desc}", leave=False) as file_log:
+            for job in jobs:
+                try:
+                    file_log.set_description_str(f"Current file: {job.path_src}")
+                    irods_session.data_objects.put(job.path_src, job.path_dest)
+                    t.update(job.bytes)
+                except:
+                    logger.error("Problem during transfer of " + job.path_src)
+                    raise
+                finally:
+                    irods_session.cleanup()
+            t.clear()
+
+        logger.info("File transfer complete.")
+
+        # Compute server-side checksums
+        if self.args.remote_checksums:
+            logger.info("Computing server-side checksums.")
+            self.compute_irods_checksums(session=irods_session, jobs=jobs)
+
+    def build_file_list(self):
+        """Build list of source files to transfer. iRODS paths are relative to target collection."""
+
+        source_paths = [Path(src) for src in self.args.sources]
+        output_paths = list()
+
+        for src in source_paths:
+            try:
+                abspath = src.resolve()
+            except:
+                logger.error("File not found:", src.name)
+                continue
+
+            if src.is_dir():
+                paths = abspath.glob("**/*" if self.args.recursive else "*")
+                for p in paths:
+                    if p.is_file() and not p.suffix.lower() == ".md5":
+                        output_paths.append({"spath": p, "ipath": p.relative_to(abspath)})
+            else:
+                output_paths.append({"spath": src, "ipath": Path(src.name)})
+        return output_paths
+
+    def process_md5_sums(self, paths):
+        """Check input paths for corresponding .md5 file. Generate one if missing."""
+
+        output_paths = paths.copy()
+        for file in paths:
+            p = file["spath"]
+            i = file["ipath"].parent / (p.name + ".md5")
+            upper_path = p.parent / (p.name + ".MD5")
+            lower_path = p.parent / (p.name + ".md5")
+            if upper_path.exists() and lower_path.exists():
+                logger.info(
+                    f"Found both {upper_path.name} and {lower_path.name} in {str(p.parent)}/"
+                )
+                logger.info("Removing upper case version.")
+                upper_path.unlink()
+                output_paths.append({"spath": lower_path, "ipath": i})
+            elif upper_path.exists():
+                logger.info(f"Found {upper_path.name} in {str(p.parent)}/")
+                logger.info("Renaming to " + lower_path.name)
+                upper_path.rename(upper_path.with_suffix(".md5"))
+                output_paths.append({"spath": lower_path, "ipath": i})
+            elif lower_path.exists():
+                output_paths.append({"spath": lower_path, "ipath": i})
+
+            if not lower_path.exists() and self.args.checksums:
+                with lower_path.open("w", encoding="utf-8") as file:
+                    file.write(f"{compute_md5_checksum(p)}  {p.name}")
+                output_paths.append({"spath": lower_path, "ipath": i})
+
+        return output_paths
+
+    def build_jobs(self, source_paths) -> typing.Tuple[TransferJob, ...]:
+        """Build file transfer jobs."""
+
+        transfer_jobs = []
+
+        for p in source_paths:
+            transfer_jobs.append(
+                TransferJob(
+                    path_src=str(p["spath"]),
+                    path_dest=f"{self.lz_irods_path}/{self.target_coll}/{str(p['ipath'])}",
+                    bytes=p["spath"].stat().st_size,
+                )
+            )
+
+        return tuple(sorted(transfer_jobs))
+
+    def compute_irods_checksums(self, session, jobs: typing.Tuple[TransferJob, ...]):
+        for job in jobs:
+            if not job.path_src.endswith(".md5"):
+                print(
+                    str(
+                        Path(job.path_dest).relative_to(f"{self.lz_irods_path}/{self.target_coll}/")
+                    )
+                )
+                try:
+                    data_object = session.data_objects.get(job.path_dest)
+                    data_object.chksum()
+                except Exception as e:
+                    logger.error("iRODS checksum error.")
+                    logger.error(e)
+                finally:
+                    session.cleanup()
+
+
+def setup_argparse(parser: argparse.ArgumentParser) -> None:
+    """Setup argument parser for ``cubi-tk sodar ingest``."""
+    return SodarIngest.setup_argparse(parser)

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -45,9 +45,6 @@ class SodarIngest:
             logger.error("iRODS environment file is missing.")
             sys.exit(1)
 
-        # iRODS environment
-        self.irods_env = None
-
     @classmethod
     def setup_argparse(cls, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -87,12 +84,6 @@ class SodarIngest:
         )
         parser.add_argument(
             "--collection", type=str, help="Target iRODS collection. Skips manual selection input."
-        )
-        parser.add_argument(
-            "--iinit",
-            default=False,
-            action="store_true",
-            help="Save PAM auth token to disk. Keep login active.",
         )
         parser.add_argument(
             "sources", help="One or multiple files/directories to ingest.", nargs="+"

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -75,10 +75,16 @@ class SodarIngest:
             "--yes",
             default=False,
             action="store_true",
-            help="Don't ask for permission prior to transfer.",
+            help="Don't ask for permission.",
         )
         parser.add_argument(
             "--collection", type=str, help="Target iRODS collection. Skips manual selection input."
+        )
+        parser.add_argument(
+            "--iinit",
+            default=False,
+            action="store_true",
+            help="Save PAM auth token to disk. Keep login active.",
         )
         parser.add_argument(
             "sources", help="One or multiple files/directories to ingest.", nargs="+"
@@ -129,7 +135,7 @@ class SodarIngest:
         source_paths = self.build_file_list()
 
         # Initiate iRODS session
-        irods_session = init_irods(self.irods_env_path)
+        irods_session = init_irods(self.irods_env_path, ask=not self.args.yes)
 
         # Query target collection
         logger.info("Querying landing zone collections…")

--- a/cubi_tk/sodar/ingest.py
+++ b/cubi_tk/sodar/ingest.py
@@ -120,7 +120,7 @@ class SodarIngest:
                 self.lz_irods_path = lz_info.irods_path
                 logger.info(f"Target iRods path: {self.lz_irods_path}")
             else:
-                logger.info("Target landing zone is not ACTIVE.")
+                logger.error("Target landing zone is not ACTIVE.")
                 sys.exit(1)
         else:
             self.lz_irods_path = self.args.destination
@@ -178,7 +178,7 @@ class SodarIngest:
                 print(f"{self.target_coll}/{str(d)}")
             if not self.args.yes:
                 if not input("Is this OK? [y/N] ").lower().startswith("y"):
-                    logger.error("Aborting at your request.")
+                    logger.info("Aborting at your request.")
                     sys.exit(0)
 
             for d in dirs:
@@ -208,7 +208,7 @@ class SodarIngest:
 
         if not self.args.yes:
             if not input("Is this OK? [y/N] ").lower().startswith("y"):
-                logger.error("Aborting at your request.")
+                logger.info("Aborting at your request.")
                 sys.exit(0)
 
         itransfer.put()
@@ -229,10 +229,10 @@ class SodarIngest:
             try:
                 abspath = src.resolve()
             except FileNotFoundError:
-                logger.error(f"File not found: {src.name}")
+                logger.warning(f"File not found: {src.name}")
                 continue
             except RuntimeError:
-                logger.error(f"Infinite loop: {src.name}")
+                logger.warning(f"Infinite loop: {src.name}")
                 continue
 
             if src.is_dir():

--- a/docs_manual/index.rst
+++ b/docs_manual/index.rst
@@ -14,8 +14,9 @@ Manual
 
     | :ref:`Creating ISA-tab files <man_isa_tpl>`
     | :ref:`Annotating ISA-tab files <man_isa_tab>`
-    | :ref:`Upload raw data to SODAR <man_ingest_fastq>`
-    | :ref:`Upload raw data to SODAR <man_seasnap_itransfer_results>`
+    | :ref:`Upload data to SODAR <man_sodar_ingest>`
+    | :ref:`Upload fastq files to SODAR <man_ingest_fastq>`
+    | :ref:`Upload results of the Seasnap pipeline to SODAR <man_seasnap_itransfer_results>`
     | :ref:`Create a sample info file for Sea-snap <man_write_sample_info>`
     | :ref:`Tools for archiving old projects <man_archive>`
 
@@ -51,6 +52,7 @@ Project Info
 
     man_isa_tpl
     man_isa_tab
+    man_sodar_ingest
     man_ingest_fastq
     man_itransfer_results
     man_write_sample_info

--- a/docs_manual/man_ingest_fastq.rst
+++ b/docs_manual/man_ingest_fastq.rst
@@ -1,7 +1,7 @@
 .. _man_ingest_fastq:
 
 ===========================
-Manual for ``ingest-fastq``
+Manual for ``sodar ingest-fastq``
 ===========================
 
 The ``cubi-tk sodar ingest-fastq`` command lets you upload raw data files to SODAR.

--- a/docs_manual/man_sodar_ingest.rst
+++ b/docs_manual/man_sodar_ingest.rst
@@ -1,0 +1,72 @@
+.. _man_sodar_ingest:
+
+===========================
+Manual for ``sodar ingest``
+===========================
+
+The ``cubi-tk sodar ingest`` command can be used to upload arbitrary data files to SODAR.
+It facilitates transfer of one or multiple sources into one SODAR landing zone, while optionally recursively matching and preserving the sub-folder structure.
+
+----------------
+Basic usage
+----------------
+
+.. code-block:: bash
+
+    $ cubi-tk sodar ingest [OPTION]... SOURCE [SOURCE ...] DESTINATION
+
+Where each ``SOURCE`` is a path to a folder containing files and ``DESTINATION`` is either an iRODS path to a *landing zone* in SODAR or the UUID of that *landing zone*.
+
+For seamless usage `~/.irods/irods_environment.json <https://sodar-server.readthedocs.io/en/dev/ui_irods_info.html>`_ and :ref:`~/.cubitkrc.toml<sodar-auth>` should be present.
+
+----------------
+Parameters
+----------------
+
+- ``-r, --recursive``: Recursively find files in subdirectories and create iRODS sub-collections to match directory structure.
+- ``-K, --remote-checksums``: Instruct iRODS to compute MD5 checksums of uploaded files for SODAR validation step.
+- ``-y, --yes``: Don't stop for user permission. Enables scripting with this command.
+- ``--collection``: Set target iRODS collection in landing zone. Skips user input for this selection.
+
+.. _sodar-auth:
+
+--------------------
+SODAR authentication
+--------------------
+
+To be able to access the SODAR API (which is only required, if you specify a landing zone UUID instead of an iRODS path), you also need an API token.
+For token management in SODAR, the following docs can be used:
+
+- https://sodar.bihealth.org/manual/ui_user_menu.html
+- https://sodar.bihealth.org/manual/ui_api_tokens.html
+
+There are three options how to supply the token.
+Only one is needed.
+The options are the following:
+
+1. configure ``~/.cubitkrc.toml``.
+
+    .. code-block:: toml
+
+        [global]
+
+        sodar_server_url = "https://sodar.bihealth.org/"
+        sodar_api_token = "<your API token here>"
+
+2. pass via command line.
+
+    .. code-block:: bash
+
+        $ cubi-tk sodar ingest-fastq --sodar-url "https://sodar.bihealth.org/" --sodar-api-token "<your API token here>"
+
+3. set as environment variable.
+
+    .. code-block:: bash
+
+        $ SODAR_API_TOKEN="<your API token here>"
+
+----------------
+More Information
+----------------
+
+Also see ``cubi-tk sodar ingest`` :ref:`CLI documentation <cli>` and ``cubi-tk sodar ingest --help`` for more information.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -65,4 +65,4 @@ simplejson
 sodar-cli ==0.1.0
 
 # Python iRODS client
-python-irodsclient==1.1.3
+python-irodsclient==1.1.8

--- a/tests/test_irods_utils.py
+++ b/tests/test_irods_utils.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import shutil
+from unittest.mock import patch
+
+from irods.session import iRODSSession
+import pytest
+
+from cubi_tk.irods_utils import TransferJob, iRODSTransfer
+
+
+@pytest.fixture
+def fake_filesystem(fs):
+    yield fs
+
+
+@pytest.fixture
+def jobs():
+    return (
+        TransferJob(path_src="myfile.csv", path_dest="dest_dir/myfile.csv", bytes=123),
+        TransferJob(
+            path_src="folder/file.csv",
+            path_dest="dest_dir/folder/file.csv",
+            bytes=1024,
+        ),
+    )
+
+
+@pytest.fixture
+def itransfer(jobs):
+    session = iRODSSession(
+        irods_host="localhost",
+        irods_port=1247,
+        irods_user_name="pytest",
+        irods_zone_name="pytest",
+    )
+
+    return iRODSTransfer(session, jobs)
+
+
+def test_irods_transfer_init(jobs, itransfer):
+    assert itransfer.total_bytes == sum([job.bytes for job in jobs])
+    assert itransfer.destinations == [job.path_dest for job in jobs]
+
+
+def test_irods_transfer_put(fs, itransfer):
+    fs.create_file("myfile.csv")
+    fs.create_dir("folder")
+    fs.create_file("folder/file.csv")
+    fs.create_dir("dest_dir/folder")
+
+    with patch.object(itransfer.session.data_objects, "put", wraps=shutil.copy):
+        itransfer.put()
+    assert Path("dest_dir/myfile.csv").exists()
+    assert Path("dest_dir/folder/file.csv").exists()
+
+
+def test_irods_transfer_chksum(itransfer):
+    with patch.object(itransfer.session.data_objects, "get") as mock:
+        itransfer.chksum()
+
+        assert mock.called
+        assert mock.called_with(itransfer.destinations)

--- a/tests/test_irods_utils.py
+++ b/tests/test_irods_utils.py
@@ -99,9 +99,8 @@ def test_irods_transfer_put(fs, itransfer, jobs):
         fs.create_file(job.path_src)
         fs.create_dir(Path(job.path_dest).parent)
 
-    with patch.object(itransfer.session.data_objects, "get"):
-        with patch.object(itransfer.session.data_objects, "put", wraps=shutil.copy):
-            itransfer.put()
+    with patch.object(itransfer.session.data_objects, "put", wraps=shutil.copy):
+        itransfer.put()
 
     for job in jobs:
         assert Path(job.path_dest).exists()

--- a/tests/test_irods_utils.py
+++ b/tests/test_irods_utils.py
@@ -2,15 +2,23 @@ from pathlib import Path
 import shutil
 from unittest.mock import patch
 
+import irods.exception
 from irods.session import iRODSSession
 import pytest
 
-from cubi_tk.irods_utils import TransferJob, init_irods, iRODSTransfer
+from cubi_tk.irods_utils import TransferJob, get_irods_error, init_irods, iRODSTransfer
 
 
 @pytest.fixture
 def fake_filesystem(fs):
     yield fs
+
+
+def test_get_irods_error():
+    e = irods.exception.NetworkException()
+    assert get_irods_error(e) == "NetworkException"
+    e = irods.exception.NetworkException("Connection reset")
+    assert get_irods_error(e) == "Connection reset"
 
 
 @patch("cubi_tk.irods_utils.iRODSSession")

--- a/tests/test_irods_utils.py
+++ b/tests/test_irods_utils.py
@@ -99,8 +99,9 @@ def test_irods_transfer_put(fs, itransfer, jobs):
         fs.create_file(job.path_src)
         fs.create_dir(Path(job.path_dest).parent)
 
-    with patch.object(itransfer.session.data_objects, "put", wraps=shutil.copy):
-        itransfer.put()
+    with patch.object(itransfer.session.data_objects, "get"):
+        with patch.object(itransfer.session.data_objects, "put", wraps=shutil.copy):
+            itransfer.put()
 
     for job in jobs:
         assert Path(job.path_dest).exists()

--- a/tests/test_sodar_ingest.py
+++ b/tests/test_sodar_ingest.py
@@ -1,7 +1,7 @@
 """Tests for ``cubi_tk.sodar.ingest``."""
 
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
@@ -35,8 +35,49 @@ def test_run_sodar_ingest_nothing(capsys):
 
 
 @pytest.fixture
-def ingest():
-    obj = SodarIngest(args={"sources": "testfolder", "recursive": True})
-    obj.lz_irods_path = "/irodsZone"
-    obj.target_coll = "targetCollection"
-    return obj
+def fake_filesystem(fs):
+    yield fs
+
+
+def test_sodar_ingest_build_file_list(fs, caplog):
+    class DummyArgs(object):
+        pass
+
+    fs.create_symlink("/not_existing", "/broken_link")
+    fs.create_symlink("/loop_src", "/loop_src2")
+    fs.create_symlink("/loop_src2", "/loop_src")
+
+    args = DummyArgs()
+    args.sources = ["broken_link", "not_here", "loop_src", "testdir"]
+    args.recursive = True
+    dummy = MagicMock()
+    args_mock = PropertyMock(return_value=args)
+    type(dummy).args = args_mock
+
+    fs.create_dir("/testdir/subdir")
+    fs.create_file("/testdir/file1")
+    fs.create_file("/testdir/file1.md5")
+    fs.create_file("/testdir/subdir/file2")
+    fs.create_file("/file3")
+    fs.create_symlink("/testdir/file3", "/file3")
+
+    paths = SodarIngest.build_file_list(dummy)
+
+    # Sources
+    assert "File not found: broken_link" in caplog.messages
+    assert "File not found: not_here" in caplog.messages
+    assert "Symlink loop: loop_src" in caplog.messages
+
+    # Files
+    assert {"spath": Path("/testdir/file1"), "ipath": Path("file1")} in paths
+    assert {"spath": Path("/testdir/file1.md5"), "ipath": Path("file1.md5")} not in paths
+    assert {"spath": Path("/testdir/subdir/file2"), "ipath": Path("subdir/file2")} in paths
+    assert {"spath": Path("/testdir/file3"), "ipath": Path("file3")} in paths
+
+    # Re-run without recursive search
+    args.recursive = False
+    paths = SodarIngest.build_file_list(dummy)
+    assert {"spath": Path("/testdir/file1"), "ipath": Path("file1")} in paths
+    assert {"spath": Path("/testdir/file1.md5"), "ipath": Path("file1.md5")} not in paths
+    assert {"spath": Path("/testdir/subdir/file2"), "ipath": Path("subdir/file2")} not in paths
+    assert {"spath": Path("/testdir/file3"), "ipath": Path("file3")} in paths

--- a/tests/test_sodar_ingest.py
+++ b/tests/test_sodar_ingest.py
@@ -46,7 +46,15 @@ def ingest(fs):
     fs.create_dir(Path.home().joinpath(".irods"))
     fs.create_file(Path.home().joinpath(".irods", "irods_environment.json"))
 
-    argv = ["--recursive", "testdir", "target"]
+    argv = [
+        "--recursive",
+        "--sodar-url",
+        "sodar_url",
+        "--sodar-api-token",
+        "token",
+        "testdir",
+        "target",
+    ]
 
     parser = ArgumentParser()
     SodarIngest.setup_argparse(parser)

--- a/tests/test_sodar_ingest.py
+++ b/tests/test_sodar_ingest.py
@@ -75,8 +75,9 @@ def test_sodar_ingest_build_file_list(fs, caplog):
     fs.create_symlink("/loop_src2", "/loop_src")
 
     args = DummyArgs()
-    args.sources = ["broken_link", "not_here", "loop_src", "testdir"]
+    args.sources = ["broken_link", "not_here", "loop_src", "testdir", "testdir", "file5"]
     args.recursive = True
+    args.exclude = ["file4", "file5"]
     dummy = MagicMock()
     args_mock = PropertyMock(return_value=args)
     type(dummy).args = args_mock
@@ -86,6 +87,8 @@ def test_sodar_ingest_build_file_list(fs, caplog):
     fs.create_file("/testdir/file1.md5")
     fs.create_file("/testdir/subdir/file2")
     fs.create_file("/file3")
+    fs.create_file("/testdir/file4")
+    fs.create_file("/file5")
     fs.create_symlink("/testdir/file3", "/file3")
 
     paths = SodarIngest.build_file_list(dummy)
@@ -120,6 +123,8 @@ def test_sodar_ingest_build_file_list(fs, caplog):
         "ipath": Path("subdir/file2"),
     } not in paths
     assert {"spath": Path("/testdir/file3"), "ipath": Path("file3")} in paths
+    assert {"spath": Path("/testdir/file4"), "ipath": Path("file4")} not in paths
+    assert {"spath": Path("file5"), "ipath": Path("file5")} not in paths
 
 
 @patch("cubi_tk.sodar.ingest.sorted")

--- a/tests/test_sodar_ingest.py
+++ b/tests/test_sodar_ingest.py
@@ -1,0 +1,31 @@
+"""Tests for ``cubi_tk.sodar.ingest``."""
+
+import pytest
+from unittest import mock
+from pyfakefs import fake_filesystem, fake_pathlib
+from cubi_tk.__main__ import main, setup_argparse
+
+
+def test_run_sodar_ingest_help(capsys):
+    parser, _subparsers = setup_argparse()
+    with pytest.raises(SystemExit) as e:
+        parser.parse_args(["sodar", "ingest", "--help"])
+
+    assert e.value.code == 0
+
+    res = capsys.readouterr()
+    assert res.out
+    assert not res.err
+
+
+def test_run_sodar_ingest_nothing(capsys):
+    parser, _subparsers = setup_argparse()
+
+    with pytest.raises(SystemExit) as e:
+        parser.parse_args(["sodar", "ingest"])
+
+    assert e.value.code == 2
+
+    res = capsys.readouterr()
+    assert not res.out
+    assert res.err

--- a/tests/test_sodar_ingest.py
+++ b/tests/test_sodar_ingest.py
@@ -1,9 +1,8 @@
 """Tests for ``cubi_tk.sodar.ingest``."""
 
 import pytest
-from unittest import mock
-from pyfakefs import fake_filesystem, fake_pathlib
-from cubi_tk.__main__ import main, setup_argparse
+
+from cubi_tk.__main__ import setup_argparse
 
 
 def test_run_sodar_ingest_help(capsys):

--- a/tests/test_sodar_ingest.py
+++ b/tests/test_sodar_ingest.py
@@ -1,7 +1,7 @@
 """Tests for ``cubi_tk.sodar.ingest``."""
 
-import os
 from argparse import ArgumentParser
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, call, patch
 

--- a/tests/test_sodar_ingest.py
+++ b/tests/test_sodar_ingest.py
@@ -1,8 +1,12 @@
 """Tests for ``cubi_tk.sodar.ingest``."""
 
+from pathlib import Path
+from unittest.mock import Mock, patch
+
 import pytest
 
 from cubi_tk.__main__ import setup_argparse
+from cubi_tk.sodar.ingest import SodarIngest
 
 
 def test_run_sodar_ingest_help(capsys):
@@ -28,3 +32,34 @@ def test_run_sodar_ingest_nothing(capsys):
     res = capsys.readouterr()
     assert not res.out
     assert res.err
+
+
+@pytest.fixture
+def ingest():
+    obj = SodarIngest(args={"sources": "testfolder", "recursive": True})
+    obj.lz_irods_path = "/irodsZone"
+    obj.target_coll = "targetCollection"
+    return obj
+
+
+@patch("cubi_tk.sodar.ingest.sorted")
+@patch("cubi_tk.sodar.ingest.compute_md5_checksum", return_value="5555")
+@patch("cubi_tk.sodar.ingest.Path.stat")
+@patch("cubi_tk.sodar.ingest.TransferJob")
+def test_sodar_ingest_build_jobs(mockjob, mockstats, mockmd5, mocksorted, ingest):
+    paths = [
+        {"spath": Path("myfile.csv"), "ipath": Path("dest_dir/myfile.csv")},
+        {"spath": Path("folder/file.csv"), "ipath": Path("dest_dir/folder/file.csv")},
+    ]
+    mockstats.return_value = Mock(st_size=1024)
+
+    ingest.build_jobs(paths)
+    print(mockjob.call_args_list)
+    for p in paths:
+        mockjob.assert_any_call(
+            path_src=str(p["spath"]),
+            path_dest=f"{ingest.lz_irods_path}/{ingest.target_coll}/{str(p['ipath'])}",
+            bytes=1024,
+            md5="5555",
+        )
+

--- a/tests/test_sodar_ingest.py
+++ b/tests/test_sodar_ingest.py
@@ -40,26 +40,3 @@ def ingest():
     obj.lz_irods_path = "/irodsZone"
     obj.target_coll = "targetCollection"
     return obj
-
-
-@patch("cubi_tk.sodar.ingest.sorted")
-@patch("cubi_tk.sodar.ingest.compute_md5_checksum", return_value="5555")
-@patch("cubi_tk.sodar.ingest.Path.stat")
-@patch("cubi_tk.sodar.ingest.TransferJob")
-def test_sodar_ingest_build_jobs(mockjob, mockstats, mockmd5, mocksorted, ingest):
-    paths = [
-        {"spath": Path("myfile.csv"), "ipath": Path("dest_dir/myfile.csv")},
-        {"spath": Path("folder/file.csv"), "ipath": Path("dest_dir/folder/file.csv")},
-    ]
-    mockstats.return_value = Mock(st_size=1024)
-
-    ingest.build_jobs(paths)
-    print(mockjob.call_args_list)
-    for p in paths:
-        mockjob.assert_any_call(
-            path_src=str(p["spath"]),
-            path_dest=f"{ingest.lz_irods_path}/{ingest.target_coll}/{str(p['ipath'])}",
-            bytes=1024,
-            md5="5555",
-        )
-


### PR DESCRIPTION
This adds a generic `sodar ingest` command which tries to mimic the base functionality of `irsync`, boosted by the power of using SODAR's API. Features include:

- no dependency on icommands; uses `iinit` session file if present, asks for password otherwise
- multiple source locations, single target collection
- recursive file matching
- creation of matched sub-folders in iRODS
- destination either as iRODS path or SODAR LZ UUID
- uses SODAR API for UUID destination & for querying LZ collections
- computes local checksums if missing
- triggers remote iRODS checksum computation
- scriptable; all user input can be skipped
- has a cool progress bar

Please try it out! Would appreciate lots of feedback.

I made this while learning Python, so please be patient. :-)