### PR TITLE
feat: allow for existing files when using irods download

### DIFF
--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -1,6 +1,5 @@
-import os
-
 from datetime import datetime
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -23,7 +22,9 @@ class PullDataCommon(IrodsCheckCommand):
     file_type_to_extensions_dict = None
 
     def __init__(self):
-        IrodsCheckCommand.__init__(self, args=SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME))
+        IrodsCheckCommand.__init__(
+            self, args=SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME)
+        )
 
     def filter_irods_collection(self, identifiers, remote_files_dict, file_type):
         """Filter iRODS collection based on identifiers (sample id or library name) and file type/extension.
@@ -95,7 +96,9 @@ class PullDataCommon(IrodsCheckCommand):
         :return: Returns assay UUID.
         """
         investigation = api.samplesheet.retrieve(
-            sodar_url=sodar_url, sodar_api_token=sodar_api_token, project_uuid=project_uuid
+            sodar_url=sodar_url,
+            sodar_api_token=sodar_api_token,
+            project_uuid=project_uuid,
         )
         for study in investigation.studies.values():
             for _assay_uuid in study.assays:
@@ -116,7 +119,9 @@ class PullDataCommon(IrodsCheckCommand):
         """
         kw_options = {}
         if force_overwrite:
-            kw_options = {FORCE_FLAG_KW: None}  # Keyword has no value, just needs to be present
+            kw_options = {
+                FORCE_FLAG_KW: None
+            }  # Keyword has no value, just needs to be present
         # Connect to iRODS
         with self._get_irods_sessions(count=1) as irods_sessions:
             try:
@@ -129,10 +134,14 @@ class PullDataCommon(IrodsCheckCommand):
                     Path(local_out_path).parent.mkdir(parents=True, exist_ok=True)
                     # Get file
                     if os.path.exists(local_out_path) and not force_overwrite:
-                        logger.info(f"{file_name} already exists. Force_overwrite to re-download.")
+                        logger.info(
+                            f"{file_name} already exists. Force_overwrite to re-download."
+                        )
                     else:
                         logger.info(f"Retrieving '{file_name}' from: {irods_path}")
-                        irods_sessions[0].data_objects.get(irods_path, local_out_path, **kw_options)
+                        irods_sessions[0].data_objects.get(
+                            irods_path, local_out_path, **kw_options
+                        )
 
             except OVERWRITE_WITHOUT_FORCE_FLAG:
                 logger.error(

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -22,9 +22,7 @@ class PullDataCommon(IrodsCheckCommand):
     file_type_to_extensions_dict = None
 
     def __init__(self):
-        IrodsCheckCommand.__init__(
-            self, args=SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME)
-        )
+        IrodsCheckCommand.__init__(self, args=SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME))
 
     def filter_irods_collection(self, identifiers, remote_files_dict, file_type):
         """Filter iRODS collection based on identifiers (sample id or library name) and file type/extension.
@@ -119,9 +117,7 @@ class PullDataCommon(IrodsCheckCommand):
         """
         kw_options = {}
         if force_overwrite:
-            kw_options = {
-                FORCE_FLAG_KW: None
-            }  # Keyword has no value, just needs to be present
+            kw_options = {FORCE_FLAG_KW: None}  # Keyword has no value, just needs to be present
         # Connect to iRODS
         with self._get_irods_sessions(count=1) as irods_sessions:
             try:
@@ -134,14 +130,10 @@ class PullDataCommon(IrodsCheckCommand):
                     Path(local_out_path).parent.mkdir(parents=True, exist_ok=True)
                     # Get file
                     if os.path.exists(local_out_path) and not force_overwrite:
-                        logger.info(
-                            f"{file_name} already exists. Force_overwrite to re-download."
-                        )
+                        logger.info(f"{file_name} already exists. Force_overwrite to re-download.")
                     else:
                         logger.info(f"Retrieving '{file_name}' from: {irods_path}")
-                        irods_sessions[0].data_objects.get(
-                            irods_path, local_out_path, **kw_options
-                        )
+                        irods_sessions[0].data_objects.get(irods_path, local_out_path, **kw_options)
 
             except OVERWRITE_WITHOUT_FORCE_FLAG:
                 logger.error(

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -1,3 +1,5 @@
+import os
+
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -123,11 +125,14 @@ class PullDataCommon(IrodsCheckCommand):
                     file_name = pair[0].split("/")[-1]
                     irods_path = pair[0]
                     local_out_path = pair[1]
-                    logger.info(f"Retrieving '{file_name}' from: {irods_path}")
                     # Create output directory if necessary
                     Path(local_out_path).parent.mkdir(parents=True, exist_ok=True)
                     # Get file
-                    irods_sessions[0].data_objects.get(irods_path, local_out_path, **kw_options)
+                    if os.path.exists(local_out_path) and not force_overwrite:
+                        logger.info(f"{file_name} already exists. Force_overwrite to re-download.")
+                    else:
+                        logger.info(f"Retrieving '{file_name}' from: {irods_path}")
+                        irods_sessions[0].data_objects.get(irods_path, local_out_path, **kw_options)
 
             except OVERWRITE_WITHOUT_FORCE_FLAG:
                 logger.error(


### PR DESCRIPTION
This fixes #175 by first comparing the filepath and only issuing the irods get if the file does not already exists.

# Limitations

This does not perform a md5 checksum

# Implementation details

Irods pythonclient directly issues a download from the get command if a localpath is included:   [ def get(self, path, local_path = None, num_threads = DEFAULT_NUMBER_OF_THREADS, **options):](https://github.com/irods/python-irodsclient/blob/bb03bb5bccf650838ae6468e6f90c60325a07997/irods/manager/data_object_manager.py#L111)

This unfortunately does not perform a md5 check against an existing file and instead only offers clobbering or fails with an exception.

## Possible alternative implementations

We can also handle this in the exception handler and trust the irods library to raise the correct expection. This would be more dependent on the specific irods library logic.