### PR TITLE
fix: use increment, not sub-total, for tqdm.update

### DIFF
--- a/cubi_tk/org_raw/check.py
+++ b/cubi_tk/org_raw/check.py
@@ -109,7 +109,7 @@ def _check(ok: Value, counter: Value, path: Path, args, t: tqdm.tqdm):
     run_check(ok, path, args)
 
     with counter.get_lock():
-        counter.value += path.stat().st_size
+        counter.value = path.stat().st_size
         t.update(counter.value)
 
 

--- a/cubi_tk/org_raw/organize.py
+++ b/cubi_tk/org_raw/organize.py
@@ -76,7 +76,7 @@ def _organize(ok: Value, counter: Value, job: OrganizeJob, args, t: tqdm.tqdm):
         run_check(ok, job.dest, args)
 
     with counter.get_lock():
-        counter.value += data_size
+        counter.value = data_size
         t.update(counter.value)
 
 

--- a/cubi_tk/sea_snap/itransfer_results.py
+++ b/cubi_tk/sea_snap/itransfer_results.py
@@ -195,7 +195,7 @@ def irsync_transfer(job: TransferJob, counter: Value, t: tqdm.tqdm):
             raise
 
     with counter.get_lock():
-        counter.value += job.bytes
+        counter.value = job.bytes
         try:
             t.update(counter.value)
         except TypeError:

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -73,7 +73,7 @@ def irsync_transfer(job: TransferJob, counter: Value, t: tqdm.tqdm):
         raise
 
     with counter.get_lock():
-        counter.value += job.bytes
+        counter.value = job.bytes
         try:
             t.update(counter.value)
         except TypeError:
@@ -697,7 +697,7 @@ def compute_md5sum(job: TransferJob, counter: Value, t: tqdm.tqdm) -> None:
         raise e
 
     with counter.get_lock():
-        counter.value += os.path.getsize(job.path_src[: -len(".md5")])
+        counter.value = os.path.getsize(job.path_src[: -len(".md5")])
         try:
             t.update(counter.value)
         except TypeError:

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -300,7 +300,7 @@ def download_folder(job: TransferJob, counter: Value, t: tqdm.tqdm):
         raise
 
     with counter.get_lock():
-        counter.value += job.bytes
+        counter.value = job.bytes
         t.update(counter.value)
 
 


### PR DESCRIPTION
This bug caused progress bars across many party of cubi-tk to show wrong numbers.

Relevant documentation: https://tqdm.github.io/docs/tqdm/#update

fixes #167 
fixes #31 