### PR TITLE
feat: Fast irods querying

### DIFF
--- a/cubi_tk/irods/check.py
+++ b/cubi_tk/irods/check.py
@@ -112,7 +112,7 @@ class IrodsCheckCommand:
         str, typing.Union[typing.Dict[str, iRODSDataObject], typing.List[iRODSDataObject]]
     ]:
         """Get data objects recursively under the given iRODS path."""
-        data_objs = dict(files=[], checksums=[])
+        data_objs = dict(files=[], checksums={})
         ignore_schemes = [k.lower() for k in HASH_SCHEMES if k != self.args.hash_scheme.upper()]
         irods_sess = root_coll.manager.sess
 
@@ -188,10 +188,10 @@ class IrodsCheckCommand:
             self.run_checks(data_objs)
             logger.info("All done")
 
-    def run_checks(self, data_objs: typing.List[iRODSDataObject]):
+    def run_checks(self, data_objs: dict):
         """Run checks on files, in parallel if enabled."""
-        num_files = len(data_objs)
-        dsp_files = data_objs
+        num_files = len(data_objs["files"])
+        dsp_files = data_objs["files"]
         if self.args.num_display_files > 0:
             dsp_files = dsp_files[: self.args.num_display_files]
         lst_files = "\n".join([f.path for f in dsp_files])

--- a/cubi_tk/irods/check.py
+++ b/cubi_tk/irods/check.py
@@ -113,14 +113,20 @@ class IrodsCheckCommand:
         data_objs = dict(files=[], checksums={})
         ignore_schemes = [k.lower() for k in HASH_SCHEMES if k != self.args.hash_scheme.upper()]
         irods_sess = root_coll.manager.sess
-        query = irods_sess.query(DataObjectModel, CollectionModel.name).filter(
+        #logger.info('Starting irods query')
+        query = irods_sess.query(DataObjectModel, CollectionModel).filter(
             Criterion('like', CollectionModel.name, root_coll.path + "%"))
         for res in query:
-            obj = irods_sess.data_objects.get(res[CollectionModel.name] + '/' + res[DataObjectModel.name])
+            #If the 'res' dict is not split into Colllection&Object the resulting iRODSDataObject is not fully functional, likely because a name/path/... attribute is overwritten somewhere 
+            coll_res = {k: v for k,v in res.items() if k.icat_id >= 500}
+            obj_res = {k: v for k,v in res.items() if k.icat_id < 500}
+            coll = iRODSCollection(root_coll.manager, coll_res)
+            obj = iRODSDataObject( irods_sess.data_objects, parent = coll, results=[obj_res])
             if obj.path.endswith("." + self.args.hash_scheme.lower()):
                 data_objs["checksums"][obj.path] = obj
             elif obj.path.split(".")[-1] not in ignore_schemes:
                 data_objs["files"].append(obj)
+        #logger.info('all objects collected')
         return data_objs
 
     def check_args(self, _args):

--- a/cubi_tk/irods/check.py
+++ b/cubi_tk/irods/check.py
@@ -9,13 +9,11 @@ import re
 import typing
 
 from irods.collection import iRODSCollection
+from irods.column import Like
 from irods.data_object import iRODSDataObject
-from irods.session import iRODSSession
 from irods.models import Collection as CollectionModel
 from irods.models import DataObject as DataObjectModel
-from irods.column import Like
-
-
+from irods.session import iRODSSession
 from logzero import logger
 import tqdm
 
@@ -108,24 +106,26 @@ class IrodsCheckCommand:
         es = str(e)
         return es if es != "None" else e.__class__.__name__
 
-    def get_data_objs(self, root_coll: iRODSCollection) -> typing.Dict[str, typing.Union[typing.Dict[str, iRODSDataObject], typing.List[iRODSDataObject]]]:
+    def get_data_objs(
+        self, root_coll: iRODSCollection
+    ) -> typing.Dict[
+        str, typing.Union[typing.Dict[str, iRODSDataObject], typing.List[iRODSDataObject]]
+    ]:
         """Get data objects recursively under the given iRODS path."""
         data_objs = dict(files=[], checksums=[])
         ignore_schemes = [k.lower() for k in HASH_SCHEMES if k != self.args.hash_scheme.upper()]
         irods_sess = root_coll.manager.sess
 
-        query = irods_sess.query(
-            DataObjectModel, CollectionModel
-        ).filter(
+        query = irods_sess.query(DataObjectModel, CollectionModel).filter(
             Like(CollectionModel.name, f"{root_coll.path}%")
         )
 
         for res in query:
             # If the 'res' dict is not split into Colllection&Object the resulting iRODSDataObject is not fully functional, likely because a name/path/... attribute is overwritten somewhere
-            coll_res = {k: v for k,v in res.items() if k.icat_id >= 500}
-            obj_res = {k: v for k,v in res.items() if k.icat_id < 500}
+            coll_res = {k: v for k, v in res.items() if k.icat_id >= 500}
+            obj_res = {k: v for k, v in res.items() if k.icat_id < 500}
             coll = iRODSCollection(root_coll.manager, coll_res)
-            obj = iRODSDataObject( irods_sess.data_objects, parent = coll, results=[obj_res])
+            obj = iRODSDataObject(irods_sess.data_objects, parent=coll, results=[obj_res])
 
             if obj.path.endswith("." + self.args.hash_scheme.lower()):
                 data_objs["checksums"][obj.path] = obj

--- a/cubi_tk/snappy/check_remote.py
+++ b/cubi_tk/snappy/check_remote.py
@@ -258,7 +258,7 @@ class Checker:
         # Restrict dictionary to directories associated with step
         subset_remote_files_dict = {}
         for key in self.remote_files_dict:
-            if all((check_name in dat.irods_path for dat in self.remote_files_dict[key])):
+            if all((check_name in dat.path for dat in self.remote_files_dict[key])):
                 subset_remote_files_dict[key] = self.remote_files_dict.get(key)
 
         # Parse local files - remove library reference
@@ -333,7 +333,7 @@ class Checker:
             # Compare to remote MD5
             for irods_dat in remote_dict.get(original_file_name):
                 if local_md5 != irods_dat.FILE_MD5SUM:
-                    different_md5_list.append((md5_file.replace(".md5", ""), irods_dat.irods_path))
+                    different_md5_list.append((md5_file.replace(".md5", ""), irods_dat.path))
                 else:
                     same_md5_list.append(md5_file.replace(".md5", ""))
                 # BONUS - check remote replicas
@@ -345,7 +345,7 @@ class Checker:
                 ):
                     logger.error(
                         f"iRODS metadata checksum not consistent with checksum file...\n"
-                        f"File: {irods_dat.irods_path}\n"
+                        f"File: {irods_dat.path}\n"
                         f"File checksum: {irods_dat.FILE_MD5SUM}\n"
                         f"Metadata checksum: {', '.join(irods_dat.REPLICAS_MD5SUM)}\n"
                     )
@@ -393,7 +393,7 @@ class Checker:
         # Only remote
         for file_ in all_remote_files_set - all_local_files_set:
             for irods_dat in remote_dict[file_]:
-                only_remote_set.add(irods_dat.irods_path)
+                only_remote_set.add(irods_dat.path)
 
         # Only local
         for file_ in all_local_files_set - all_remote_files_set:
@@ -419,7 +419,7 @@ class Checker:
         inner_dict = {}
         for file_, irods_list in remote_dict.items():
             if len(irods_list) > 1:
-                inner_dict[file_] = [dat.irods_path for dat in irods_list]
+                inner_dict[file_] = [dat.path for dat in irods_list]
         # Format and display information - if any
         if len(inner_dict) > 0:
             pairs_str = ""

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -31,7 +31,7 @@ class PullDataCommon(IrodsCheckCommand):
         :type identifiers: list
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``DataObject``).
+        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``iRODSDataObject``).
         :type remote_files_dict: dict
 
         :param file_type: File type, example: 'bam' or 'vcf'.
@@ -175,7 +175,7 @@ class PullDataCommon(IrodsCheckCommand):
         /sodarZone/projects/../<PROJECT_UUID>/.../assay_<ASSAY_UUID>/<LIBRARY_NAME>/.../<DATE>/...
 
         :param irods_obj_list: List of iRODS objects derived from collection in SODAR.
-        :type irods_obj_list: List[DataObject]
+        :type irods_obj_list: List[iRODSDataObject]
 
         :return: Returns inputted list sorted from latest to earliest iRODS object.
         """

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -31,7 +31,7 @@ class PullDataCommon(IrodsCheckCommand):
         :type identifiers: list
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``IrodsDataObject``).
+        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``DataObject``).
         :type remote_files_dict: dict
 
         :param file_type: File type, example: 'bam' or 'vcf'.
@@ -175,7 +175,7 @@ class PullDataCommon(IrodsCheckCommand):
         /sodarZone/projects/../<PROJECT_UUID>/.../assay_<ASSAY_UUID>/<LIBRARY_NAME>/.../<DATE>/...
 
         :param irods_obj_list: List of iRODS objects derived from collection in SODAR.
-        :type irods_obj_list: List[IrodsDataObject]
+        :type irods_obj_list: List[DataObject]
 
         :return: Returns inputted list sorted from latest to earliest iRODS object.
         """

--- a/cubi_tk/snappy/pull_data_common.py
+++ b/cubi_tk/snappy/pull_data_common.py
@@ -53,7 +53,7 @@ class PullDataCommon(IrodsCheckCommand):
             # Note: if a file with the same name is present in both assay and in a common file, it will be ignored.
             in_common_links = False
             for irods_obj in value:
-                in_common_links = self._irods_path_in_common_links(irods_obj.irods_path)
+                in_common_links = self._irods_path_in_common_links(irods_obj.path)
                 if in_common_links:
                     break
 
@@ -184,7 +184,7 @@ class PullDataCommon(IrodsCheckCommand):
             return irods_obj_list
         return sorted(
             irods_obj_list,
-            key=lambda irods_obj: self._find_date_in_path(irods_obj.irods_path),
+            key=lambda irods_obj: self._find_date_in_path(irods_obj.path),
             reverse=True,
         )
 

--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -208,7 +208,7 @@ class PullProcessedDataCommand(PullDataCommon):
         # Find all remote files (iRODS)
         pseudo_args = SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME)
         extensions_tuple = self.file_type_to_extensions_dict.get(self.args.file_type)
-        remote_file_objs = RetrieveIrodsCollection(
+        remote_files_dict = RetrieveIrodsCollection(
             pseudo_args,
             self.args.sodar_url,
             self.args.sodar_api_token,
@@ -219,11 +219,11 @@ class PullProcessedDataCommand(PullDataCommon):
         # Filter based on identifiers and file type
         filtered_remote_files_dict = self.filter_irods_collection(
             identifiers=selected_identifiers,
-            remote_files_dict=remote_file_objs,
+            remote_files_dict=remote_files_dict,
             file_type=self.args.file_type,
         )
         if len(filtered_remote_files_dict) == 0:
-            self.report_no_file_found(available_files=[*remote_file_objs])
+            self.report_no_file_found(available_files=[*remote_files_dict])
             return 0
 
         # Pair iRODS path with output path

--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -299,7 +299,7 @@ class PullProcessedDataCommand(PullDataCommon):
         """Pair iRODS path with local output directory
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001-N1-DNA1-WES1'); Value: iRODS data (``IrodsDataObject``).
+        'P001-N1-DNA1-WES1'); Value: iRODS data (``DataObject``).
         :type remote_files_dict: dict
 
         :param output_dir: Output directory path.

--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -299,7 +299,7 @@ class PullProcessedDataCommand(PullDataCommon):
         """Pair iRODS path with local output directory
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001-N1-DNA1-WES1'); Value: iRODS data (``DataObject``).
+        'P001-N1-DNA1-WES1'); Value: iRODS data (``iRODSDataObject``).
         :type remote_files_dict: dict
 
         :param output_dir: Output directory path.

--- a/cubi_tk/snappy/pull_processed_data.py
+++ b/cubi_tk/snappy/pull_processed_data.py
@@ -207,13 +207,14 @@ class PullProcessedDataCommand(PullDataCommon):
 
         # Find all remote files (iRODS)
         pseudo_args = SimpleNamespace(hash_scheme=DEFAULT_HASH_SCHEME)
+        extensions_tuple = self.file_type_to_extensions_dict.get(self.args.file_type)
         remote_files_dict = RetrieveIrodsCollection(
             pseudo_args,
             self.args.sodar_url,
             self.args.sodar_api_token,
             self.args.assay_uuid,
             self.args.project_uuid,
-        ).perform()
+        ).perform(identifiers=selected_identifiers, extensions_tuple=extensions_tuple)
 
         # Filter based on identifiers and file type
         filtered_remote_files_dict = self.filter_irods_collection(

--- a/cubi_tk/snappy/pull_raw_data.py
+++ b/cubi_tk/snappy/pull_raw_data.py
@@ -255,7 +255,7 @@ class PullRawDataCommand(PullDataCommon):
         :type identifiers: list
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``IrodsDataObject``).
+        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``DataObject``).
         :type remote_files_dict: dict
 
         :param file_type: File type, example: 'fastq'.
@@ -302,7 +302,7 @@ class PullRawDataCommand(PullDataCommon):
         """Pair iRODS path with local output directory
 
         :param library_to_irods_dict: Dictionary with iRODS collection information by sample. Key: sample name as
-        string (e.g., 'P001'); Value: iRODS data (``IrodsDataObject``).
+        string (e.g., 'P001'); Value: iRODS data (``DataObject``).
         :type library_to_irods_dict: dict
 
         :param identifiers_tuples: List of tuples (sample name, folder name) as defined in the sample sheet.
@@ -357,7 +357,7 @@ class PullRawDataCommand(PullDataCommon):
         :type identifiers: list
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001_R1_001.fastq.gz'); Value: iRODS data (``IrodsDataObject``).
+        'P001_R1_001.fastq.gz'); Value: iRODS data (``DataObject``).
         :type remote_files_dict: dict
 
         :return: Returns dictionary: Key: identifier (sample name [str]); Value: list of iRODS objects.

--- a/cubi_tk/snappy/pull_raw_data.py
+++ b/cubi_tk/snappy/pull_raw_data.py
@@ -255,7 +255,7 @@ class PullRawDataCommand(PullDataCommon):
         :type identifiers: list
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``DataObject``).
+        'P001-N1-DNA1-WES1.vcf.gz'); Value: iRODS data (``iRODSDataObject``).
         :type remote_files_dict: dict
 
         :param file_type: File type, example: 'fastq'.
@@ -302,7 +302,7 @@ class PullRawDataCommand(PullDataCommon):
         """Pair iRODS path with local output directory
 
         :param library_to_irods_dict: Dictionary with iRODS collection information by sample. Key: sample name as
-        string (e.g., 'P001'); Value: iRODS data (``DataObject``).
+        string (e.g., 'P001'); Value: iRODS data (``iRODSDataObject``).
         :type library_to_irods_dict: dict
 
         :param identifiers_tuples: List of tuples (sample name, folder name) as defined in the sample sheet.
@@ -357,7 +357,7 @@ class PullRawDataCommand(PullDataCommon):
         :type identifiers: list
 
         :param remote_files_dict: Dictionary with iRODS collection information. Key: file name as string (e.g.,
-        'P001_R1_001.fastq.gz'); Value: iRODS data (``DataObject``).
+        'P001_R1_001.fastq.gz'); Value: iRODS data (``iRODSDataObject``).
         :type remote_files_dict: dict
 
         :return: Returns dictionary: Key: identifier (sample name [str]); Value: list of iRODS objects.

--- a/cubi_tk/snappy/pull_raw_data.py
+++ b/cubi_tk/snappy/pull_raw_data.py
@@ -280,9 +280,9 @@ class PullRawDataCommand(PullDataCommon):
             in_common_links = False
             for irods_obj in value:
                 # Piggyback loop for dir check
-                _irods_path_list.append(irods_obj.irods_path)
+                _irods_path_list.append(irods_obj.path)
                 # Actual check
-                if self._irods_path_in_common_links(irods_obj.irods_path):
+                if self._irods_path_in_common_links(irods_obj.path):
                     in_common_links = True
                     break
 
@@ -332,10 +332,10 @@ class PullRawDataCommand(PullDataCommon):
                 # /sodarZone/projects/../<PROJECT_UUID>/sample_data/study_<STUDY_UUID>/assay_<ASSAY_UUID>/<LIBRARY_NAME>
                 try:
                     irods_dir_structure = os.path.dirname(
-                        str(irods_obj.irods_path).split(f"assay_{assay_uuid}/")[1]
+                        str(irods_obj.path).split(f"assay_{assay_uuid}/")[1]
                     )
                     _out_path = os.path.join(
-                        output_dir, folder_name, irods_dir_structure, irods_obj.file_name
+                        output_dir, folder_name, irods_dir_structure, irods_obj.name
                     )
                 except IndexError:
                     logger.warning(
@@ -343,10 +343,9 @@ class PullRawDataCommand(PullDataCommon):
                         f"hence directory structure won't be preserved.\n"
                         f"All files will be stored in root of output directory: {output_list}"
                     )
-                    _out_path = os.path.join(output_dir, folder_name, irods_obj.file_name)
+                    _out_path = os.path.join(output_dir, folder_name, irods_obj.name)
                 # Update output
-                output_list.append((irods_obj.irods_path, _out_path))
-                output_list.append((irods_obj.irods_path + ".md5", _out_path + ".md5"))
+                output_list.append((irods_obj.path, _out_path))
 
         return output_list
 

--- a/cubi_tk/snappy/retrieve_irods_collection.py
+++ b/cubi_tk/snappy/retrieve_irods_collection.py
@@ -106,7 +106,7 @@ class RetrieveIrodsCollection(IrodsCheckCommand):
         :param irods_path: iRODS path.
 
         :return: Returns dictionary representation of iRODS collection information. Key: File name in iRODS (str);
-        Value: list of iRodsDataObject (attributes: 'file_name', 'irods_path', 'file_md5sum', 'replicas_md5sum').
+        Value: list of iRODSDataObject (native python-irodsclient object).
         """
 
         # Connect to iRODS
@@ -136,7 +136,7 @@ class RetrieveIrodsCollection(IrodsCheckCommand):
         :type irods_collection: dict
 
         :return: Returns dictionary representation of iRODS collection information. Key: File name in iRODS (str);
-        Value: list of iRodsDataObject (attributes: 'file_name', 'irods_path', 'file_md5sum', 'replicas_md5sum').
+        Value: list of iRODSDataObject (native python-irodsclient object).
         """
         # Initialise variables
         output_dict = defaultdict(list)

--- a/cubi_tk/snappy/retrieve_irods_collection.py
+++ b/cubi_tk/snappy/retrieve_irods_collection.py
@@ -3,12 +3,11 @@
 from collections import defaultdict
 import typing
 
+from irods.data_object import iRODSDataObject
 from logzero import logger
 from sodar_cli import api
 
 from ..irods.check import IrodsCheckCommand
-
-from irods.data_object import iRODSDataObject
 
 #: Default hash scheme. Although iRODS provides alternatives, the whole of `snappy` pipeline uses MD5.
 DEFAULT_HASH_SCHEME = "MD5"
@@ -39,8 +38,7 @@ class RetrieveIrodsCollection(IrodsCheckCommand):
         self.project_uuid = project_uuid
 
     def perform(self) -> typing.Dict[str, typing.List[iRODSDataObject]]:
-        """Perform class routines.
-        """
+        """Perform class routines."""
         logger.info("Starting remote files search ...")
 
         # Get assay iRODS path
@@ -100,7 +98,9 @@ class RetrieveIrodsCollection(IrodsCheckCommand):
             f"All available UUIDs:\n{multi_assay_str}"
         )
 
-    def retrieve_irods_data_objects(self, irods_path: str) -> typing.Dict[str, typing.List[iRODSDataObject]]:
+    def retrieve_irods_data_objects(
+        self, irods_path: str
+    ) -> typing.Dict[str, typing.List[iRODSDataObject]]:
         """Retrieve data objects from iRODS.
 
         :param irods_path: iRODS path.
@@ -127,7 +127,6 @@ class RetrieveIrodsCollection(IrodsCheckCommand):
                 raise
 
         return {}
-
 
     @staticmethod
     def parse_irods_collection(irods_data_objs) -> typing.Dict[str, typing.List[iRODSDataObject]]:

--- a/cubi_tk/sodar/check_remote.py
+++ b/cubi_tk/sodar/check_remote.py
@@ -116,7 +116,7 @@ class FileComparisonChecker:
         :param local_files_dict: Dictionary with local directories as keys and list of FileDataObject as values.
         :type local_files_dict: dict
 
-        :param remote_files_dict: Dictionary with remote filenames as keys and list of IrodsDataObject as values.
+        :param remote_files_dict: Dictionary with remote filenames as keys and list of iRodsDataObject as values.
         :type remote_files_dict: dict
 
         :param filenames_only: Flag to indicate if md5 sums should not be used for comparison
@@ -165,7 +165,7 @@ class FileComparisonChecker:
         :param local_dict: Dictionary with local directories as keys and list of FileDataObject as values.
         :type local_dict: dict
 
-        :param remote_dict: Dictionary with remote filenames as keys and list of IrodsDataObject as values.
+        :param remote_dict: Dictionary with remote filenames as keys and list of iRodsDataObject as values.
         :type remote_dict: dict
 
         :param filenames_only: Flag to indicate if md5 sums should not be used for comparison
@@ -179,10 +179,10 @@ class FileComparisonChecker:
         """
 
         def filedata_from_irodsdata(obj):
-            # Helper Function to convert IrodsDataObject (non-hashable) to FileDataObject, also making path relative
-            p = Path(obj.irods_path).parent
+            # Helper Function to convert iRodsDataObject (non-hashable) to FileDataObject, also making path relative
+            p = Path(obj.path).parent
             p = p.relative_to(irods_basepath) if irods_basepath else p
-            return FileDataObject(obj.file_name, str(p), obj.file_md5sum)
+            return FileDataObject(obj.name, str(p), obj.checksum)
 
         # The dictionaries will contain double information on the file path (both as keys & in the objects)
         # For collecting info in itself sets would be easier, however grouping by folder makes it easier to
@@ -223,7 +223,7 @@ class FileComparisonChecker:
 
                 # From the file with matching names subselect those with same md5
                 md5_matches = {
-                    filedata_from_irodsdata(f) for f in remote_files if f.file_md5sum == md5
+                    filedata_from_irodsdata(f) for f in remote_files if f.checksum == md5
                 }
                 if md5_matches:
                     remote_unmatched -= md5_matches

--- a/cubi_tk/sodar/check_remote.py
+++ b/cubi_tk/sodar/check_remote.py
@@ -116,7 +116,7 @@ class FileComparisonChecker:
         :param local_files_dict: Dictionary with local directories as keys and list of FileDataObject as values.
         :type local_files_dict: dict
 
-        :param remote_files_dict: Dictionary with remote filenames as keys and list of iRodsDataObject as values.
+        :param remote_files_dict: Dictionary with remote filenames as keys and list of iRODSDataObject as values.
         :type remote_files_dict: dict
 
         :param filenames_only: Flag to indicate if md5 sums should not be used for comparison
@@ -165,7 +165,7 @@ class FileComparisonChecker:
         :param local_dict: Dictionary with local directories as keys and list of FileDataObject as values.
         :type local_dict: dict
 
-        :param remote_dict: Dictionary with remote filenames as keys and list of iRodsDataObject as values.
+        :param remote_dict: Dictionary with remote filenames as keys and list of iRODSDataObject as values.
         :type remote_dict: dict
 
         :param filenames_only: Flag to indicate if md5 sums should not be used for comparison

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,50 @@
+from typing import List
+import pathlib
+
+from irods.data_object import iRODSDataObject
+from irods.collection import iRODSCollection
+from irods.models import DataObject, Collection
+
+
+class iRODSDataObjectEq(iRODSDataObject):
+    name: str
+    path: str
+    checksum: str
+
+    def __eq__(self, other):
+        return self.name == other.name and self.path == other.path and self.checksum == other.checksum
+
+
+
+def createIrodsDataObject(file_name: str, irods_path: str, file_md5sum: str, replicas_md5sum: List[str]):
+    """Create iRODSDataObject from parameters.
+    """
+
+    parent = pathlib.Path(irods_path).parent
+    collection_data = {
+        Collection.id: 0,
+        Collection.name: str(parent),
+        Collection.create_time: None,
+        Collection.modify_time: None,
+        Collection.inheritance: None,
+        Collection.owner_name: None,
+        Collection.owner_zone: None,
+    }
+    collection = iRODSCollection(None, result=collection_data)
+
+    data_object_datas = []
+    for i, rep_md5sum in enumerate(replicas_md5sum):
+        data_object_datas.append({
+            DataObject.id: 0,
+            DataObject.name: file_name,
+            DataObject.replica_number: i,
+            DataObject.replica_status: None,
+            DataObject.resource_name: None,
+            DataObject.path: irods_path,
+            DataObject.resc_hier: None,
+            DataObject.checksum: rep_md5sum,
+            DataObject.size: 0,
+            DataObject.comments: "",
+        })
+    obj = iRODSDataObjectEq(None, parent=collection, results=data_object_datas)
+    return obj

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,9 +1,9 @@
-from typing import List
 import pathlib
+from typing import List
 
-from irods.data_object import iRODSDataObject
 from irods.collection import iRODSCollection
-from irods.models import DataObject, Collection
+from irods.data_object import iRODSDataObject
+from irods.models import Collection, DataObject
 
 
 class iRODSDataObjectEq(iRODSDataObject):
@@ -12,13 +12,15 @@ class iRODSDataObjectEq(iRODSDataObject):
     checksum: str
 
     def __eq__(self, other):
-        return self.name == other.name and self.path == other.path and self.checksum == other.checksum
+        return (
+            self.name == other.name and self.path == other.path and self.checksum == other.checksum
+        )
 
 
-
-def createIrodsDataObject(file_name: str, irods_path: str, file_md5sum: str, replicas_md5sum: List[str]):
-    """Create iRODSDataObject from parameters.
-    """
+def createIrodsDataObject(
+    file_name: str, irods_path: str, file_md5sum: str, replicas_md5sum: List[str]
+):
+    """Create iRODSDataObject from parameters."""
 
     parent = pathlib.Path(irods_path).parent
     collection_data = {
@@ -34,17 +36,19 @@ def createIrodsDataObject(file_name: str, irods_path: str, file_md5sum: str, rep
 
     data_object_datas = []
     for i, rep_md5sum in enumerate(replicas_md5sum):
-        data_object_datas.append({
-            DataObject.id: 0,
-            DataObject.name: file_name,
-            DataObject.replica_number: i,
-            DataObject.replica_status: None,
-            DataObject.resource_name: None,
-            DataObject.path: irods_path,
-            DataObject.resc_hier: None,
-            DataObject.checksum: rep_md5sum,
-            DataObject.size: 0,
-            DataObject.comments: "",
-        })
+        data_object_datas.append(
+            {
+                DataObject.id: 0,
+                DataObject.name: file_name,
+                DataObject.replica_number: i,
+                DataObject.replica_status: None,
+                DataObject.resource_name: None,
+                DataObject.path: irods_path,
+                DataObject.resc_hier: None,
+                DataObject.checksum: rep_md5sum,
+                DataObject.size: 0,
+                DataObject.comments: "",
+            }
+        )
     obj = iRODSDataObjectEq(None, parent=collection, results=data_object_datas)
     return obj

--- a/tests/test_snappy_check_remote.py
+++ b/tests/test_snappy_check_remote.py
@@ -4,7 +4,9 @@ import pathlib
 import pytest
 
 from cubi_tk.snappy.check_remote import Checker, FindLocalFiles, FindLocalRawdataFiles
-from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+# from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+
+from .helpers import createIrodsDataObject
 
 # Tests FindLocalFiles =================================================================================================
 
@@ -87,7 +89,7 @@ def test_compare_local_and_remote_files():
     replicas_md5sum = [file_md5sum] * 3
     in_remote_dict = {
         "bwa.P001-N1-DNA1-WES1.bam": [
-            IrodsDataObject(
+            createIrodsDataObject(
                 file_name="bwa.P001-N1-DNA1-WES1.bam",
                 irods_path="/sodar_path/bwa.P001-N1-DNA1-WES1.bam",
                 file_md5sum=file_md5sum,
@@ -95,7 +97,7 @@ def test_compare_local_and_remote_files():
             )
         ],
         "bwa.P001-N1-DNA1-WES1.bam.bai": [
-            IrodsDataObject(
+            createIrodsDataObject(
                 file_name="bwa.P001-N1-DNA1-WES1.bam.bai",
                 irods_path="/sodar_path/bwa.P001-N1-DNA1-WES1.bam.bai",
                 file_md5sum=file_md5sum,
@@ -103,7 +105,7 @@ def test_compare_local_and_remote_files():
             )
         ],
         "bwa.P002-N1-DNA1-WES1.bam": [
-            IrodsDataObject(
+            createIrodsDataObject(
                 file_name="bwa.P002-N1-DNA1-WES1.bam",
                 irods_path="/sodar_path/bwa.P002-N1-DNA1-WES1.bam",
                 file_md5sum=file_md5sum,
@@ -111,7 +113,7 @@ def test_compare_local_and_remote_files():
             )
         ],
         "bwa.P002-N1-DNA1-WES1.bam.bai": [
-            IrodsDataObject(
+            createIrodsDataObject(
                 file_name="bwa.P002-N1-DNA1-WES1.bam.bai",
                 irods_path="/sodar_path/bwa.P002-N1-DNA1-WES1.bam.bai",
                 file_md5sum=file_md5sum,
@@ -165,7 +167,7 @@ def test_compare_local_and_remote_files():
     # Update input and expected results
     extra_remote_files_dict = {
         "bwa.P001-N1-DNA1-WES1.conda_info.txt": [
-            IrodsDataObject(
+            createIrodsDataObject(
                 file_name="bwa.P001-N1-DNA1-WES1.conda_info.txt",
                 irods_path="/sodar_path/bwa.P001-N1-DNA1-WES1.conda_info.txt",
                 file_md5sum=file_md5sum,

--- a/tests/test_snappy_check_remote.py
+++ b/tests/test_snappy_check_remote.py
@@ -4,9 +4,11 @@ import pathlib
 import pytest
 
 from cubi_tk.snappy.check_remote import Checker, FindLocalFiles, FindLocalRawdataFiles
-# from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
 
 from .helpers import createIrodsDataObject
+
+# from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+
 
 # Tests FindLocalFiles =================================================================================================
 

--- a/tests/test_snappy_pull_data_common.py
+++ b/tests/test_snappy_pull_data_common.py
@@ -4,7 +4,7 @@
 import pytest
 
 from cubi_tk.snappy.pull_data_common import PullDataCommon
-from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+from .helpers import createIrodsDataObject as IrodsDataObject
 
 # Empty file MD5 checksum
 FILE_MD5SUM = "d41d8cd98f00b204e9800998ecf8427e"
@@ -99,7 +99,7 @@ def test_pull_data_common_sort_irods_object_by_date_in_path(irods_objects_list):
     expected = ("2038-01-19", "2000-01-01", "1999-09-09")
     actual = raw_data_class.sort_irods_object_by_date_in_path(irods_obj_list=irods_objects_list)
     for count, irods_obj in enumerate(actual):
-        assert expected[count] in irods_obj.irods_path
+        assert expected[count] in irods_obj.path
 
 
 def test_pull_data_common_sort_irods_object_by_date_in_path_mixed(irods_objects_list_format_mixed):
@@ -110,7 +110,7 @@ def test_pull_data_common_sort_irods_object_by_date_in_path_mixed(irods_objects_
         irods_obj_list=irods_objects_list_format_mixed
     )
     for count, irods_obj in enumerate(actual):
-        assert expected[count] in irods_obj.irods_path
+        assert expected[count] in irods_obj.path
 
 
 def test_pull_data_common_sort_irods_object_by_date_in_path_missing_date(

--- a/tests/test_snappy_pull_data_common.py
+++ b/tests/test_snappy_pull_data_common.py
@@ -4,6 +4,7 @@
 import pytest
 
 from cubi_tk.snappy.pull_data_common import PullDataCommon
+
 from .helpers import createIrodsDataObject as IrodsDataObject
 
 # Empty file MD5 checksum

--- a/tests/test_snappy_pull_processed_data.py
+++ b/tests/test_snappy_pull_processed_data.py
@@ -5,6 +5,7 @@ import pytest
 
 from cubi_tk.__main__ import setup_argparse
 from cubi_tk.snappy.pull_processed_data import PullProcessedDataCommand
+
 from .helpers import createIrodsDataObject as IrodsDataObject
 
 # Empty file MD5 checksum
@@ -480,14 +481,10 @@ def test_pull_processed_data_pair_ipath_with_outdir_bam(pull_processed_data, rem
         "out_dir/P00{i}-N1-DNA1-WES1/1999-09-09/ngs_mapping/bwa.P00{i}-N1-DNA1-WES1.{ext}"
     )
     irods_files_list = [
-        irods_path.format(i=i, ext=ext)
-        for i in (1, 2)
-        for ext in ("bam", "bam.bai")
+        irods_path.format(i=i, ext=ext) for i in (1, 2) for ext in ("bam", "bam.bai")
     ]
     correct_uuid_output_dir_list = [
-        full_out_dir.format(i=i, ext=ext)
-        for i in (1, 2)
-        for ext in ("bam", "bam.bai")
+        full_out_dir.format(i=i, ext=ext) for i in (1, 2) for ext in ("bam", "bam.bai")
     ]
     wrong_uuid_output_dir_list = [
         "out_dir/bwa.P00{i}-N1-DNA1-WES1.{ext}".format(i=i, ext=ext)
@@ -570,14 +567,10 @@ def test_pull_processed_data_pair_ipath_with_outdir_vcf(pull_processed_data, rem
         "out_dir/P00{i}-N1-DNA1-WES1/1999-09-09/variant_calling/bwa.P00{i}-N1-DNA1-WES1.{ext}"
     )
     irods_files_list = [
-        irods_path.format(i=i, ext=ext)
-        for i in (1, 2)
-        for ext in ("vcf.gz", "vcf.gz.tbi")
+        irods_path.format(i=i, ext=ext) for i in (1, 2) for ext in ("vcf.gz", "vcf.gz.tbi")
     ]
     correct_uuid_output_dir_list = [
-        full_out_dir.format(i=i, ext=ext)
-        for i in (1, 2)
-        for ext in ("vcf.gz", "vcf.gz.tbi")
+        full_out_dir.format(i=i, ext=ext) for i in (1, 2) for ext in ("vcf.gz", "vcf.gz.tbi")
     ]
     wrong_uuid_output_dir_list = [
         "out_dir/bwa.P00{i}-N1-DNA1-WES1.{ext}".format(i=i, ext=ext)

--- a/tests/test_snappy_pull_processed_data.py
+++ b/tests/test_snappy_pull_processed_data.py
@@ -5,7 +5,7 @@ import pytest
 
 from cubi_tk.__main__ import setup_argparse
 from cubi_tk.snappy.pull_processed_data import PullProcessedDataCommand
-from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+from .helpers import createIrodsDataObject as IrodsDataObject
 
 # Empty file MD5 checksum
 FILE_MD5SUM = "d41d8cd98f00b204e9800998ecf8427e"
@@ -482,17 +482,17 @@ def test_pull_processed_data_pair_ipath_with_outdir_bam(pull_processed_data, rem
     irods_files_list = [
         irods_path.format(i=i, ext=ext)
         for i in (1, 2)
-        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+        for ext in ("bam", "bam.bai")
     ]
     correct_uuid_output_dir_list = [
         full_out_dir.format(i=i, ext=ext)
         for i in (1, 2)
-        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+        for ext in ("bam", "bam.bai")
     ]
     wrong_uuid_output_dir_list = [
         "out_dir/bwa.P00{i}-N1-DNA1-WES1.{ext}".format(i=i, ext=ext)
         for i in (1, 2)
-        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+        for ext in ("bam", "bam.bai")
     ]
     correct_uuid_expected = []
     for _irods_path, _out_path in zip(irods_files_list, correct_uuid_output_dir_list):
@@ -532,13 +532,13 @@ def test_pull_processed_data_pair_ipath_with_outdir_bam_retrieve_all(
         irods_path.format(i=i, date=date, ext=ext)
         for i in (1, 2)
         for date in ("1999-09-09", "1975-01-04")
-        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+        for ext in ("bam", "bam.bai")
     ]
     correct_uuid_output_dir_list = [
         full_out_dir.format(i=i, date=date, ext=ext)
         for i in (1, 2)
         for date in ("1999-09-09", "1975-01-04")
-        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+        for ext in ("bam", "bam.bai")
     ]
     correct_uuid_expected = []
     for _irods_path, _out_path in zip(irods_files_list, correct_uuid_output_dir_list):
@@ -572,17 +572,17 @@ def test_pull_processed_data_pair_ipath_with_outdir_vcf(pull_processed_data, rem
     irods_files_list = [
         irods_path.format(i=i, ext=ext)
         for i in (1, 2)
-        for ext in ("vcf.gz", "vcf.gz.tbi", "vcf.gz.md5", "vcf.gz.tbi.md5")
+        for ext in ("vcf.gz", "vcf.gz.tbi")
     ]
     correct_uuid_output_dir_list = [
         full_out_dir.format(i=i, ext=ext)
         for i in (1, 2)
-        for ext in ("vcf.gz", "vcf.gz.tbi", "vcf.gz.md5", "vcf.gz.tbi.md5")
+        for ext in ("vcf.gz", "vcf.gz.tbi")
     ]
     wrong_uuid_output_dir_list = [
         "out_dir/bwa.P00{i}-N1-DNA1-WES1.{ext}".format(i=i, ext=ext)
         for i in (1, 2)
-        for ext in ("vcf.gz", "vcf.gz.tbi", "vcf.gz.md5", "vcf.gz.tbi.md5")
+        for ext in ("vcf.gz", "vcf.gz.tbi")
     ]
     correct_uuid_expected = []
     for _irods_path, _out_path in zip(irods_files_list, correct_uuid_output_dir_list):

--- a/tests/test_snappy_pull_raw_data.py
+++ b/tests/test_snappy_pull_raw_data.py
@@ -5,7 +5,8 @@ import pytest
 
 from cubi_tk.__main__ import setup_argparse
 from cubi_tk.snappy.pull_raw_data import Config, PullRawDataCommand
-from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+
+from .helpers import createIrodsDataObject as IrodsDataObject
 
 # Empty file MD5 checksum
 FILE_MD5SUM = "d41d8cd98f00b204e9800998ecf8427e"
@@ -259,7 +260,7 @@ def test_pull_raw_data_get_library_to_irods_dict(pull_raw_data, remote_files_fas
         identifiers=samples_list, remote_files_dict=remote_files_fastq
     )
     for id_ in samples_list:
-        assert all([str(irods.file_name).startswith(id_) for irods in actual.get(id_)])
+        assert all([str(irods.name).startswith(id_) for irods in actual.get(id_)])
 
 
 def test_pull_raw_data_pair_ipath_with_folder_name(pull_raw_data, sample_to_irods_dict):
@@ -280,19 +281,19 @@ def test_pull_raw_data_pair_ipath_with_folder_name(pull_raw_data, sample_to_irod
         irods_path.format(i=i, r=r, ext=ext)
         for i in (1, 2)
         for r in (1, 2)
-        for ext in ("fastq.gz", "fastq.gz.md5")
+        for ext in ("fastq.gz",)
     ]
     correct_uuid_output_dir_list = [
         full_out_dir.format(i=i, r=r, ext=ext)
         for i in (1, 2)
         for r in (1, 2)
-        for ext in ("fastq.gz", "fastq.gz.md5")
+        for ext in ("fastq.gz",)
     ]
     wrong_uuid_output_dir_list = [
         "out_dir/P00{i}/P00{i}_R{r}_001.{ext}".format(i=i, r=r, ext=ext)
         for i in (1, 2)
         for r in (1, 2)
-        for ext in ("fastq.gz", "fastq.gz.md5")
+        for ext in ("fastq.gz",)
     ]
     correct_uuid_expected = []
     for _irods_path, _out_path in zip(irods_files_list, correct_uuid_output_dir_list):

--- a/tests/test_sodar_check_remote.py
+++ b/tests/test_sodar_check_remote.py
@@ -127,11 +127,6 @@ def test_filecomparisoncheck_compare_local_and_remote_files():
     actual_both, actual_local, actual_remote = FileComparisonChecker.compare_local_and_remote_files(
         local_dict, remote_dict
     )
-    from pprint import pprint
-
-    pprint(actual_both)
-    pprint(actual_local)
-    pprint(actual_remote)
     assert expected_both == actual_both
     assert expected_local == actual_local
     assert expected_remote == actual_remote

--- a/tests/test_sodar_check_remote.py
+++ b/tests/test_sodar_check_remote.py
@@ -2,7 +2,7 @@
 
 import pathlib
 
-from cubi_tk.snappy.retrieve_irods_collection import IrodsDataObject
+from .helpers import createIrodsDataObject as IrodsDataObject
 from cubi_tk.sodar.check_remote import (
     FileComparisonChecker,
     FileDataObject,
@@ -73,20 +73,20 @@ def test_filecomparisoncheck_compare_local_and_remote_files():
     remote_dict = {
         "test1.txt": [
             IrodsDataObject(
-                "test1.txt", "test1/test1.txt", "fa029a7f2a3ca5a03fe682d3b77c7f0d", 3 * [None]
+                "test1.txt", "/test1/test1.txt", "fa029a7f2a3ca5a03fe682d3b77c7f0d", 3 * ["fa029a7f2a3ca5a03fe682d3b77c7f0d"]
             )
         ],
         "test2.txt": [
             IrodsDataObject(
-                "test2.txt", "test2/test2.txt", "856babf68edfd13e2fd019df330e11c5", 3 * [None]
+                "test2.txt", "/test2/test2.txt", "856babf68edfd13e2fd019df330e11c5", 3 * ["856babf68edfd13e2fd019df330e11c5"]
             )
         ],
         "test3.txt": [
             IrodsDataObject(
-                "test3.txt", "test3/test3.txt", "0f034ea35fde3fca41d71cbcb13ee659", 3 * [None]
+                "test3.txt", "/test3/test3.txt", "0f034ea35fde3fca41d71cbcb13ee659", 3 * ["0f034ea35fde3fca41d71cbcb13ee659"]
             )
         ],
-        "test5.txt": [IrodsDataObject("test5.txt", "test5/test5.txt", "abcdefgh", 3 * [None])],
+        "test5.txt": [IrodsDataObject("test5.txt", "/test5/test5.txt", "abcdefgh", 3 * ["abcdefgh"])],
     }
     # Setup (local) FileDataObjects:
     test1 = FileDataObject(
@@ -109,19 +109,23 @@ def test_filecomparisoncheck_compare_local_and_remote_files():
     expected_both = {test_dir_path / "test1": [test1], test_dir_path / "test2": [test2]}
     expected_local = {test_dir_path / "test3": [test3], test_dir_path / "test4": [test4]}
     expected_remote = {
-        "test3": [FileDataObject("test3.txt", "test3", "0f034ea35fde3fca41d71cbcb13ee659")],
-        "test5": [FileDataObject("test5.txt", "test5", "abcdefgh")],
+        "/test3": [FileDataObject("test3.txt", "/test3", "0f034ea35fde3fca41d71cbcb13ee659")],
+        "/test5": [FileDataObject("test5.txt", "/test5", "abcdefgh")],
     }
     actual_both, actual_local, actual_remote = FileComparisonChecker.compare_local_and_remote_files(
         local_dict, remote_dict
     )
+    from pprint import pprint
+    pprint(actual_both)
+    pprint(actual_local)
+    pprint(actual_remote)
     assert expected_both == actual_both
     assert expected_local == actual_local
     assert expected_remote == actual_remote
     # Check matching by filename only (test3 moves to expected_both)
     expected_both.update({test_dir_path / "test3": [test3]})
     expected_local.pop(test_dir_path / "test3")
-    expected_remote.pop("test3")
+    expected_remote.pop("/test3")
     actual_both, actual_local, actual_remote = FileComparisonChecker.compare_local_and_remote_files(
         local_dict, remote_dict, filenames_only=True
     )

--- a/tests/test_sodar_check_remote.py
+++ b/tests/test_sodar_check_remote.py
@@ -2,12 +2,13 @@
 
 import pathlib
 
-from .helpers import createIrodsDataObject as IrodsDataObject
 from cubi_tk.sodar.check_remote import (
     FileComparisonChecker,
     FileDataObject,
     FindLocalMD5Files,
 )
+
+from .helpers import createIrodsDataObject as IrodsDataObject
 
 
 def test_findlocalmd5_run():
@@ -73,20 +74,31 @@ def test_filecomparisoncheck_compare_local_and_remote_files():
     remote_dict = {
         "test1.txt": [
             IrodsDataObject(
-                "test1.txt", "/test1/test1.txt", "fa029a7f2a3ca5a03fe682d3b77c7f0d", 3 * ["fa029a7f2a3ca5a03fe682d3b77c7f0d"]
+                "test1.txt",
+                "/test1/test1.txt",
+                "fa029a7f2a3ca5a03fe682d3b77c7f0d",
+                3 * ["fa029a7f2a3ca5a03fe682d3b77c7f0d"],
             )
         ],
         "test2.txt": [
             IrodsDataObject(
-                "test2.txt", "/test2/test2.txt", "856babf68edfd13e2fd019df330e11c5", 3 * ["856babf68edfd13e2fd019df330e11c5"]
+                "test2.txt",
+                "/test2/test2.txt",
+                "856babf68edfd13e2fd019df330e11c5",
+                3 * ["856babf68edfd13e2fd019df330e11c5"],
             )
         ],
         "test3.txt": [
             IrodsDataObject(
-                "test3.txt", "/test3/test3.txt", "0f034ea35fde3fca41d71cbcb13ee659", 3 * ["0f034ea35fde3fca41d71cbcb13ee659"]
+                "test3.txt",
+                "/test3/test3.txt",
+                "0f034ea35fde3fca41d71cbcb13ee659",
+                3 * ["0f034ea35fde3fca41d71cbcb13ee659"],
             )
         ],
-        "test5.txt": [IrodsDataObject("test5.txt", "/test5/test5.txt", "abcdefgh", 3 * ["abcdefgh"])],
+        "test5.txt": [
+            IrodsDataObject("test5.txt", "/test5/test5.txt", "abcdefgh", 3 * ["abcdefgh"])
+        ],
     }
     # Setup (local) FileDataObjects:
     test1 = FileDataObject(
@@ -116,6 +128,7 @@ def test_filecomparisoncheck_compare_local_and_remote_files():
         local_dict, remote_dict
     )
     from pprint import pprint
+
     pprint(actual_both)
     pprint(actual_local)
     pprint(actual_remote)


### PR DESCRIPTION
Still work in progress but already reduces irods pull commands to <30s. Querying all files from a single sodar assay takes ~2.5s. The slow part is reading each `md5` checksum.

# Todo

- [x] clean up codebase
- [x] make filtering step cleaner
- [x] clean up checksum extraction

Since irods already offers native checksumming, its unclear whether the current md5 checksums are really necessary. This should be cleared up.