### PR TITLE
fix: Update ISA-tpl dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ attrs
 cattrs
 
 # For ISA-tab templates.
-cookiecutter==2.3.0
+cookiecutter==2.3.1
 cubi-isa-templates==0.1.0
 
 # Easy logging.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ cattrs
 
 # For ISA-tab templates.
 cookiecutter==2.3.1
-cubi-isa-templates==0.1.0
+cubi-isa-templates==0.1.1
 
 # Easy logging.
 logzero


### PR DESCRIPTION
v0.1 of cubi-isa-templates contained a workaround for NCIT accession IDs which is no longer needed and in fact clashes with the fix deployed in the latest SODAR version.
 
Also, Cookiecutter fixed a display bug: https://github.com/cookiecutter/cookiecutter/issues/1939