### PR TITLE
feat: Common functions for interfacing with python-irodsclient

### DIFF
--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -8,9 +8,9 @@ from typing import Iterable
 import attrs
 from irods.exception import (
     CAT_INVALID_AUTHENTICATION,
-    PAM_AUTH_PASSWORD_FAILED,
-    CAT_PASSWORD_EXPIRED,
     CAT_INVALID_USER,
+    CAT_PASSWORD_EXPIRED,
+    PAM_AUTH_PASSWORD_FAILED,
 )
 from irods.password_obfuscation import encode
 from irods.session import NonAnonymousLoginWithoutPassword, iRODSSession

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -31,7 +31,10 @@ class TransferJob:
     path_dest: str
 
     #: Number of bytes to transfer.
-    bytes: int
+    bytes: str = attr.field()
+    @bytes.default
+    def _get_file_size(self):
+        return Path(self.path_src).stat().st_size
 
 
 class iRODSCommon:

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -22,7 +22,7 @@ NUM_PARALLEL_SESSIONS = 4
 
 @attr.s(frozen=True, auto_attribs=True)
 class TransferJob:
-    """Encodes a transfer job from the local file system to the remote iRODS collection."""
+    """Encodes a transfer job from the local file system to a remote iRODS collection."""
 
     #: Source path.
     path_src: str
@@ -30,8 +30,9 @@ class TransferJob:
     #: Destination path.
     path_dest: str
 
-    #: Number of bytes to transfer.
+    #: Number of bytes to transfer (optional).
     bytes: str = attr.field()
+
     @bytes.default
     def _get_file_size(self):
         return Path(self.path_src).stat().st_size

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -172,7 +172,7 @@ class iRODSTransfer(iRODSCommon):
         collection = str(Path(job.path_dest).parent)
         self.session.collections.create(collection)
 
-    def put(self, recursive: bool = False):
+    def put(self, recursive: bool = False, sync: bool = False):
         # Double tqdm for currently transferred file info
         # TODO: add more parenthesis after python 3.10
         with tqdm(
@@ -189,6 +189,9 @@ class iRODSTransfer(iRODSCommon):
                 try:
                     if recursive:
                         self._create_collections(job)
+                    if sync and self.session.data_objects.exists(job.path_dest):
+                        t.update(job.bytes)
+                        continue
                     self.session.data_objects.put(job.path_src, job.path_dest)
                     t.update(job.bytes)
                 except Exception as e:  # pragma: no cover

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -39,6 +39,7 @@ class iRODSCommon:
 
     def __init__(self, ask: bool = False):
         #: Path to iRODS environment file
+        # TODO: custom env path
         self.irods_env_path = Path.home().joinpath(".irods", "irods_environment.json")
         self.ask = ask
 
@@ -127,17 +128,18 @@ class iRODSCommon:
                 irods.cleanup()
 
 
-class iRODSTransfer:
+class iRODSTransfer(iRODSCommon):
     """
     Transfer files to iRODS.
 
     Attributes:
-    session -- initialised iRODSSession
     jobs -- iterable of TransferJob objects
     """
 
-    def __init__(self, session: iRODSSession, jobs: Iterable[TransferJob]):
-        self.session = session
+    def __init__(self, jobs: Iterable[TransferJob]):
+        super().__init__()
+        with self._get_irods_sessions(1) as s:
+            self.session = s[0]  # TODO: use more sessions
         self.jobs = jobs
         self.total_bytes = sum([job.bytes for job in self.jobs])
         self.destinations = [job.path_dest for job in self.jobs]

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -35,12 +35,20 @@ class TransferJob:
 
 
 class iRODSCommon:
-    """Implementation of common iRODS utility functions."""
+    """
+    Implementation of common iRODS utility functions.
 
-    def __init__(self, ask: bool = False):
-        #: Path to iRODS environment file
-        # TODO: custom env path
-        self.irods_env_path = Path.home().joinpath(".irods", "irods_environment.json")
+    Attributes:
+    ask -- Confirm with user before certain actions.
+    irods_env_path -- Path to irods_environment.json
+    """
+
+    def __init__(self, ask: bool = False, irods_env_path: Path = None):
+        # Path to iRODS environment file
+        if irods_env_path is None:
+            self.irods_env_path = Path.home().joinpath(".irods", "irods_environment.json")
+        else:
+            self.irods_env_path = irods_env_path
         self.ask = ask
 
         # check for outdated .irodsA file
@@ -136,8 +144,8 @@ class iRODSTransfer(iRODSCommon):
     jobs -- iterable of TransferJob objects
     """
 
-    def __init__(self, jobs: Iterable[TransferJob]):
-        super().__init__()
+    def __init__(self, jobs: Iterable[TransferJob], **kwargs):
+        super().__init__(**kwargs)
         with self._get_irods_sessions(1) as s:
             self.session = s[0]  # TODO: use more sessions
         self.jobs = jobs

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -1,7 +1,6 @@
 import getpass
 import os.path
 from pathlib import Path
-import sys
 from typing import Iterable
 
 import attrs
@@ -116,7 +115,7 @@ class iRODSCommon:
                     raise e
             except Exception as e:  # pragma: no cover
                 logger.error(f"iRODS connection failed: {self.get_irods_error(e)}")
-                sys.exit(1)
+                raise RuntimeError
 
         if self.ask and input(
             "Save iRODS session for passwordless operation? [y/N] "
@@ -198,7 +197,6 @@ class iRODSTransfer(iRODSCommon):
                 except Exception as e:  # pragma: no cover
                     logger.error(f"Problem during transfer of {job.path_local}")
                     logger.error(self.get_irods_error(e))
-                    sys.exit(1)
             t.clear()
 
     def chksum(self):
@@ -249,5 +247,4 @@ class iRODSTransfer(iRODSCommon):
                 except Exception as e:  # pragma: no cover
                     logger.error(f"Problem during transfer of {job.path_remote}")
                     logger.error(self.get_irods_error(e))
-                    sys.exit(1)
             t.clear()

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -198,8 +198,6 @@ class iRODSTransfer(iRODSCommon):
                     logger.error(f"Problem during transfer of {job.path_src}")
                     logger.error(self.get_irods_error(e))
                     sys.exit(1)
-                finally:
-                    self.session.cleanup()
             t.clear()
 
     def chksum(self):
@@ -215,5 +213,4 @@ class iRODSTransfer(iRODSCommon):
                 except Exception as e:  # pragma: no cover
                     logger.error("Problem during iRODS checksumming.")
                     logger.error(self.get_irods_error(e))
-                finally:
-                    self.session.cleanup()
+

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -76,7 +76,8 @@ class iRODSCommon:
     def _check_auth(self):
         """Check auth status and login if needed."""
         try:
-            self._init_irods().server_version
+            with self._init_irods() as session:
+                session.server_version
             return 0
         except NonAnonymousLoginWithoutPassword as e:  # pragma: no cover
             logger.info(self.get_irods_error(e))

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -50,8 +50,6 @@ class iRODSCommon:
         else:
             self.irods_env_path = irods_env_path
         self.ask = ask
-
-        # check for outdated .irodsA file
         self._check_auth()
 
     @staticmethod

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -1,0 +1,161 @@
+import getpass
+import os.path
+from pathlib import Path
+import sys
+from typing import Iterable
+
+import attr
+from irods.exception import CAT_INVALID_AUTHENTICATION, PAM_AUTH_PASSWORD_FAILED
+from irods.password_obfuscation import encode
+from irods.session import iRODSSession
+import logzero
+from logzero import logger
+from tqdm import tqdm
+
+# no-frills logger
+formatter = logzero.LogFormatter(fmt="%(message)s")
+output_logger = logzero.setup_logger(formatter=formatter)
+
+
+@attr.s(frozen=True, auto_attribs=True)
+class TransferJob:
+    """Encodes a transfer job from the local file system to the remote iRODS collection."""
+
+    #: Source path.
+    path_src: str
+
+    #: Destination path.
+    path_dest: str
+
+    #: Number of bytes to transfer.
+    bytes: int
+
+
+def get_irods_error(e: Exception):
+    """Return logger friendly iRODS exception."""
+    es = str(e)
+    return es if es and es != "None" else e.__class__.__name__
+
+
+def init_irods(irods_env_path: Path, ask: bool = False) -> iRODSSession:
+    """Connect to iRODS."""
+    irods_auth_path = irods_env_path.parent.joinpath(".irodsA")
+    if irods_auth_path.exists():
+        try:
+            session = iRODSSession(irods_env_file=irods_env_path)
+            session.server_version  # check for outdated .irodsA file
+            session.connection_timeout = 300
+            return session
+        except Exception as e:  # pragma: no cover
+            logger.error(f"iRODS connection failed: {get_irods_error(e)}")
+            pass
+        finally:
+            session.cleanup()
+
+    # No valid .irodsA file. Query user for password.
+    logger.info("No valid iRODS authentication file found.")
+    attempts = 0
+    while attempts < 3:
+        try:
+            session = iRODSSession(
+                irods_env_file=irods_env_path,
+                password=getpass.getpass(prompt="Please enter SODAR password:"),
+            )
+            session.server_version  # check for exceptions
+            break
+        except PAM_AUTH_PASSWORD_FAILED:  # pragma: no cover
+            if attempts < 2:
+                logger.warning("Wrong password. Please try again.")
+                attempts += 1
+                continue
+            else:
+                logger.error("iRODS connection failed.")
+                sys.exit(1)
+        except Exception as e:  # pragma: no cover
+            logger.error(f"iRODS connection failed: {get_irods_error(e)}")
+            sys.exit(1)
+        finally:
+            session.cleanup()
+
+    if ask and input("Save iRODS session for passwordless operation? [y/N] ").lower().startswith(
+        "y"
+    ):
+        save_irods_token(session)  # pragma: no cover
+    elif not ask:
+        save_irods_token(session)
+
+    return session
+
+
+def save_irods_token(session: iRODSSession, irods_env_path=None):
+    """Retrieve PAM temp auth token 'obfuscate' it and save to disk."""
+    if not irods_env_path:
+        irods_auth_path = Path.home().joinpath(".irods", ".irodsA")
+    else:
+        irods_auth_path = Path(irods_env_path).parent.joinpath(".irodsA")
+
+    irods_auth_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        token = session.pam_pw_negotiated
+    except CAT_INVALID_AUTHENTICATION:  # pragma: no cover
+        raise
+
+    if isinstance(token, list) and token:
+        irods_auth_path.write_text(encode(token[0]))
+        irods_auth_path.chmod(0o600)
+
+
+class iRODSTransfer:
+    """
+    Transfer files to iRODS.
+
+    Attributes:
+    session -- initialised iRODSSession
+    jobs -- iterable of TransferJob objects
+    """
+
+    def __init__(self, session: iRODSSession, jobs: Iterable[TransferJob]):
+        self.session = session
+        self.jobs = jobs
+        self.total_bytes = sum([job.bytes for job in self.jobs])
+        self.destinations = [job.path_dest for job in self.jobs]
+
+    def put(self):
+        # Double tqdm for currently transferred file info
+        # TODO: add more parenthesis after python 3.10
+        with tqdm(
+            total=self.total_bytes,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+            position=1,
+        ) as t, tqdm(total=0, position=0, bar_format="{desc}", leave=False) as file_log:
+            for job in self.jobs:
+                file_log.set_description_str(f"Current file: {job.path_src}")
+                try:
+                    self.session.data_objects.put(job.path_src, job.path_dest)
+                    t.update(job.bytes)
+                except Exception as e:  # pragma: no cover
+                    logger.error(f"Problem during transfer of {job.path_src}")
+                    logger.error(get_irods_error(e))
+                    sys.exit(1)
+                finally:
+                    self.session.cleanup()
+            t.clear()
+
+    def chksum(self):
+        """Compute remote md5 checksums for all jobs."""
+        common_prefix = os.path.commonpath(self.destinations)
+        for job in self.jobs:
+            if not job.path_src.endswith(".md5"):
+                output_logger.info(Path(job.path_dest).relative_to(common_prefix))
+                try:
+                    data_object = self.session.data_objects.get(job.path_dest)
+                    if not data_object.checksum:
+                        data_object.chksum()
+                except Exception as e:  # pragma: no cover
+                    logger.error("Problem during iRODS checksumming.")
+                    logger.error(get_irods_error(e))
+                finally:
+                    self.session.cleanup()

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -10,6 +10,7 @@ from irods.exception import (
     CAT_INVALID_AUTHENTICATION,
     PAM_AUTH_PASSWORD_FAILED,
     CAT_PASSWORD_EXPIRED,
+    CAT_INVALID_USER,
 )
 from irods.password_obfuscation import encode
 from irods.session import NonAnonymousLoginWithoutPassword, iRODSSession
@@ -78,11 +79,16 @@ class iRODSCommon:
             try:
                 session = iRODSSession(irods_env_file=self.irods_env_path)
                 session.connection_timeout = 300
+                session.server_version
                 return session
             except NonAnonymousLoginWithoutPassword as e:  # pragma: no cover
                 logger.info(self.get_irods_error(e))
                 self._irods_login()
-            except (CAT_INVALID_AUTHENTICATION, CAT_PASSWORD_EXPIRED):  # pragma: no cover
+            except (
+                CAT_INVALID_AUTHENTICATION,
+                CAT_INVALID_USER,
+                CAT_PASSWORD_EXPIRED,
+            ):  # pragma: no cover
                 logger.warning("Problem with your session token.")
                 self.irods_env_path.parent.joinpath(".irodsA").unlink()
                 self._irods_login()

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -38,9 +38,10 @@ class iRODSCommon:
     """
     Implementation of common iRODS utility functions.
 
-    Attributes:
-    ask -- Confirm with user before certain actions.
-    irods_env_path -- Path to irods_environment.json
+    :param ask: Confirm with user before certain actions.
+    :type ask: bool, optional
+    :param irods_env_path: Path to irods_environment.json
+    :type irods_env_path: pathlib.Path, optional
     """
 
     def __init__(self, ask: bool = False, irods_env_path: Path = None):
@@ -138,8 +139,8 @@ class iRODSTransfer(iRODSCommon):
     """
     Transfer files to iRODS.
 
-    Attributes:
-    jobs -- iterable of TransferJob objects
+    :param jobs: Iterable of TransferJob objects
+    :type jobs: Union[list,tuple,dict,set]
     """
 
     def __init__(self, jobs: Iterable[TransferJob], **kwargs):

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -161,7 +161,7 @@ class iRODSTransfer(iRODSCommon):
                     t.update(job.bytes)
                 except Exception as e:  # pragma: no cover
                     logger.error(f"Problem during transfer of {job.path_src}")
-                    logger.error(get_irods_error(e))
+                    logger.error(self.get_irods_error(e))
                     sys.exit(1)
                 finally:
                     self.session.cleanup()
@@ -179,6 +179,6 @@ class iRODSTransfer(iRODSCommon):
                         data_object.chksum()
                 except Exception as e:  # pragma: no cover
                     logger.error("Problem during iRODS checksumming.")
-                    logger.error(get_irods_error(e))
+                    logger.error(self.get_irods_error(e))
                 finally:
                     self.session.cleanup()

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import sys
 from typing import Iterable
 
-import attr
+import attrs
 from irods.exception import CAT_INVALID_AUTHENTICATION, PAM_AUTH_PASSWORD_FAILED
 from irods.password_obfuscation import encode
 from irods.session import NonAnonymousLoginWithoutPassword, iRODSSession
@@ -20,7 +20,7 @@ output_logger = logzero.setup_logger(formatter=formatter)
 NUM_PARALLEL_SESSIONS = 4
 
 
-@attr.s(frozen=True, auto_attribs=True)
+@attrs.frozen(auto_attribs=True)
 class TransferJob:
     """Encodes a transfer job from the local file system to a remote iRODS collection."""
 
@@ -31,7 +31,7 @@ class TransferJob:
     path_dest: str
 
     #: Number of bytes to transfer (optional).
-    bytes: str = attr.field()
+    bytes: str = attrs.field()
 
     @bytes.default
     def _get_file_size(self):

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -177,8 +177,8 @@ class iRODSTransfer(iRODSCommon):
             unit_divisor=1024,
             position=1,
         ) as t, tqdm(total=0, position=0, bar_format="{desc}", leave=False) as file_log:
-            for job in self.__jobs:
-                file_log.set_description_str(f"Current file: {job.path_src}")
+            for n, job in enumerate(self.__jobs):
+                file_log.set_description_str(f"File [{n + 1}/{len(self.__jobs)}]: {Path(job.path_src).name}")
                 try:
                     self.session.data_objects.put(job.path_src, job.path_dest)
                     t.update(job.bytes)

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -150,6 +150,10 @@ class iRODSCommon:
             for irods in irods_sessions:
                 irods.cleanup()
 
+    @property
+    def session(self):
+        return self._init_irods()
+
 
 class iRODSTransfer(iRODSCommon):
     """

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -75,7 +75,7 @@ class iRODSCommon:
         while True:
             try:
                 session = iRODSSession(irods_env_file=self.irods_env_path)
-                session.connection_timeout = 300
+                session.connection_timeout = 600
                 session.server_version
                 return session
             except NonAnonymousLoginWithoutPassword as e:  # pragma: no cover

--- a/cubi_tk/irods_common.py
+++ b/cubi_tk/irods_common.py
@@ -220,3 +220,33 @@ class iRODSTransfer(iRODSCommon):
                     logger.error("Problem during iRODS checksumming.")
                     logger.error(self.get_irods_error(e))
 
+    def get(self):
+        """Download files from SODAR."""
+        self.__jobs = [
+            attrs.evolve(job, bytes=self.session.data_objects.get(job.path_remote).size)
+            for job in self.__jobs
+        ]
+        self.__total_bytes = sum([job.bytes for job in self.__jobs])
+        # Double tqdm for currently transferred file info
+        # TODO: add more parenthesis after python 3.10
+        with tqdm(
+            total=self.__total_bytes,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+            position=1,
+        ) as t, tqdm(total=0, position=0, bar_format="{desc}", leave=False) as file_log:
+            for n, job in enumerate(self.__jobs):
+                file_log.set_description_str(
+                    f"File [{n + 1}/{len(self.__jobs)}]: {Path(job.path_local).name}"
+                )
+                try:
+                    self.session.data_objects.get(job.path_remote, job.path_local)
+                    t.update(job.bytes)
+                except FileNotFoundError:  # pragma: no cover
+                    raise
+                except Exception as e:  # pragma: no cover
+                    logger.error(f"Problem during transfer of {job.path_remote}")
+                    logger.error(self.get_irods_error(e))
+                    sys.exit(1)
+            t.clear()

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -17,6 +17,8 @@ def fake_filesystem(fs):
 @patch("cubi_tk.irods_common.iRODSSession")
 def test_common_init(mocksession):
     assert iRODSCommon().irods_env_path is not None
+    icommon = iRODSCommon(irods_env_path="a/b/c.json")
+    assert icommon.irods_env_path == "a/b/c.json"
     assert type(iRODSCommon().ask) is bool
 
 
@@ -101,6 +103,11 @@ def itransfer(jobs):
 def test_irods_transfer_init(jobs, itransfer):
     assert itransfer.total_bytes == sum([job.bytes for job in jobs])
     assert itransfer.destinations == [job.path_dest for job in jobs]
+
+    with patch("cubi_tk.irods_common.iRODSSession") as mocksession:
+        itransferc = iRODSTransfer(jobs=jobs, irods_env_path="a/b/c", ask=True)
+        assert itransferc.irods_env_path == "a/b/c"
+        assert itransferc.ask == True
 
 
 def test_irods_transfer_put(fs, itransfer, jobs):

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -9,6 +9,10 @@ import pytest
 from cubi_tk.irods_common import TransferJob, iRODSCommon, iRODSTransfer
 
 
+def test_transfer_job_bytes(fs):
+    fs.create_file("test_file", st_size=123)
+    assert TransferJob("test_file", "remote/path").bytes == 123
+
 @patch("cubi_tk.irods_common.iRODSSession")
 def test_common_init(mocksession):
     assert iRODSCommon().irods_env_path is not None

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -23,18 +23,8 @@ def fake_filesystem(fs):
 @pytest.fixture
 def jobs():
     return (
-        TransferJob(
-            path_src="myfile.csv",
-            path_dest="dest_dir/myfile.csv",
-            bytes=123,
-            md5="ed3b3cbb18fd148bc925944ff0861ce6",
-        ),
-        TransferJob(
-            path_src="folder/file.csv",
-            path_dest="dest_dir/folder/file.csv",
-            bytes=1024,
-            md5="a6e9e3c859b803adb0f1d5f08a51d0f6",
-        ),
+        TransferJob(path_src="myfile.csv", path_dest="dest_dir/myfile.csv", bytes=123),
+        TransferJob(path_src="folder/file.csv", path_dest="dest_dir/folder/file.csv", bytes=1024),
     )
 
 
@@ -56,7 +46,7 @@ def test_get_irods_error():
     assert get_irods_error(e) == "Connection reset"
 
 
-@patch("cubi_tk.irods_utils.iRODSSession")
+@patch("cubi_tk.irods_common.iRODSSession")
 @patch("getpass.getpass")
 def test_init_irods(mockpass, mocksession, fs):
     ienv = Path(".irods/irods_environment.json")
@@ -76,7 +66,7 @@ def test_init_irods(mockpass, mocksession, fs):
     mocksession.assert_called_with(irods_env_file=ienv)
 
 
-@patch("cubi_tk.irods_utils.encode", return_value="it works")
+@patch("cubi_tk.irods_common.encode", return_value="it works")
 def test_write_token(mockencode, fs):
     ienv = Path(".irods/irods_environment.json")
 
@@ -104,9 +94,6 @@ def test_irods_transfer_put(fs, itransfer, jobs):
 
     for job in jobs:
         assert Path(job.path_dest).exists()
-        assert Path(job.path_dest + ".md5").exists()
-        with Path(job.path_dest + ".md5").open() as file:
-            assert file.readline() == f"{job.md5}  {Path(job.path_dest).name}"
 
 
 def test_irods_transfer_chksum(itransfer):

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -118,9 +118,20 @@ def test_irods_transfer_put(fs, itransfer, jobs):
 
     with patch.object(itransfer.session.data_objects, "put", wraps=shutil.copy):
         itransfer.put()
+        with patch("cubi_tk.irods_common.iRODSTransfer._create_collections") as mockrecursive:
+            itransfer.put(recursive=True)
 
     for job in jobs:
         assert Path(job.path_dest).exists()
+    mockrecursive.assert_called()
+
+
+def test_create_collections(itransfer):
+    itransfer.session.collections.create = MagicMock()
+    itransfer._create_collections(itransfer.jobs[1])
+
+    coll_path = str(Path(itransfer.jobs[1].path_dest).parent)
+    itransfer.session.collections.create.assert_called_with(coll_path)
 
 
 def test_irods_transfer_chksum(itransfer):

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -101,7 +101,8 @@ def itransfer(jobs):
 
 
 def test_irods_transfer_init(jobs, itransfer):
-    assert itransfer.total_bytes == sum([job.bytes for job in jobs])
+    assert itransfer.jobs == jobs
+    assert itransfer.size == sum([job.bytes for job in jobs])
     assert itransfer.destinations == [job.path_dest for job in jobs]
 
     with patch("cubi_tk.irods_common.iRODSSession"):

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -104,10 +104,10 @@ def test_irods_transfer_init(jobs, itransfer):
     assert itransfer.total_bytes == sum([job.bytes for job in jobs])
     assert itransfer.destinations == [job.path_dest for job in jobs]
 
-    with patch("cubi_tk.irods_common.iRODSSession") as mocksession:
+    with patch("cubi_tk.irods_common.iRODSSession"):
         itransferc = iRODSTransfer(jobs=jobs, irods_env_path="a/b/c", ask=True)
         assert itransferc.irods_env_path == "a/b/c"
-        assert itransferc.ask == True
+        assert itransferc.ask is True
 
 
 def test_irods_transfer_put(fs, itransfer, jobs):

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+import shutil
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import irods.exception
+from irods.session import iRODSSession
+import pytest
+
+from cubi_tk.irods_common import (
+    TransferJob,
+    get_irods_error,
+    init_irods,
+    iRODSTransfer,
+    save_irods_token,
+)
+
+
+@pytest.fixture
+def fake_filesystem(fs):
+    yield fs
+
+
+@pytest.fixture
+def jobs():
+    return (
+        TransferJob(
+            path_src="myfile.csv",
+            path_dest="dest_dir/myfile.csv",
+            bytes=123,
+            md5="ed3b3cbb18fd148bc925944ff0861ce6",
+        ),
+        TransferJob(
+            path_src="folder/file.csv",
+            path_dest="dest_dir/folder/file.csv",
+            bytes=1024,
+            md5="a6e9e3c859b803adb0f1d5f08a51d0f6",
+        ),
+    )
+
+
+@pytest.fixture
+def itransfer(jobs):
+    session = iRODSSession(
+        irods_host="localhost",
+        irods_port=1247,
+        irods_user_name="pytest",
+        irods_zone_name="pytest",
+    )
+    return iRODSTransfer(session, jobs)
+
+
+def test_get_irods_error():
+    e = irods.exception.NetworkException()
+    assert get_irods_error(e) == "NetworkException"
+    e = irods.exception.NetworkException("Connection reset")
+    assert get_irods_error(e) == "Connection reset"
+
+
+@patch("cubi_tk.irods_utils.iRODSSession")
+@patch("getpass.getpass")
+def test_init_irods(mockpass, mocksession, fs):
+    ienv = Path(".irods/irods_environment.json")
+    password = "1234"
+
+    # .irodsA not found, asks for password
+    mockpass.return_value = password
+    init_irods(ienv)
+    mockpass.assert_called()
+    mocksession.assert_called_with(irods_env_file=ienv, password=password)
+
+    # .irodsA there, does not ask for password
+    fs.create_file(".irods/.irodsA")
+    mockpass.reset_mock()
+    init_irods(ienv)
+    mockpass.assert_not_called()
+    mocksession.assert_called_with(irods_env_file=ienv)
+
+
+@patch("cubi_tk.irods_utils.encode", return_value="it works")
+def test_write_token(mockencode, fs):
+    ienv = Path(".irods/irods_environment.json")
+
+    mocksession = MagicMock()
+    pam_pw = PropertyMock(return_value=["secure"])
+    type(mocksession).pam_pw_negotiated = pam_pw
+
+    save_irods_token(mocksession, ienv)
+    assert ienv.parent.joinpath(".irodsA").exists()
+    mockencode.assert_called_with("secure")
+
+
+def test_irods_transfer_init(jobs, itransfer):
+    assert itransfer.total_bytes == sum([job.bytes for job in jobs])
+    assert itransfer.destinations == [job.path_dest for job in jobs]
+
+
+def test_irods_transfer_put(fs, itransfer, jobs):
+    for job in jobs:
+        fs.create_file(job.path_src)
+        fs.create_dir(Path(job.path_dest).parent)
+
+    with patch.object(itransfer.session.data_objects, "put", wraps=shutil.copy):
+        itransfer.put()
+
+    for job in jobs:
+        assert Path(job.path_dest).exists()
+        assert Path(job.path_dest + ".md5").exists()
+        with Path(job.path_dest + ".md5").open() as file:
+            assert file.readline() == f"{job.md5}  {Path(job.path_dest).name}"
+
+
+def test_irods_transfer_chksum(itransfer):
+    with patch.object(itransfer.session.data_objects, "get") as mock:
+        itransfer.chksum()
+
+        for path in itransfer.destinations:
+            mock.assert_any_call(path)

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -9,11 +9,6 @@ import pytest
 from cubi_tk.irods_common import TransferJob, iRODSCommon, iRODSTransfer
 
 
-@pytest.fixture
-def fake_filesystem(fs):
-    yield fs
-
-
 @patch("cubi_tk.irods_common.iRODSSession")
 def test_common_init(mocksession):
     assert iRODSCommon().irods_env_path is not None

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -21,7 +21,7 @@ def test_common_init(mocksession):
     icommon = iRODSCommon(irods_env_path="a/b/c.json")
     assert icommon.irods_env_path == "a/b/c.json"
     assert type(iRODSCommon().ask) is bool
-
+    assert iRODSCommon().session is mocksession.return_value
 
 @patch("cubi_tk.irods_common.iRODSSession")
 def test_get_irods_error(mocksession):

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 import shutil
-from unittest.mock import ANY, MagicMock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import irods.exception
-from irods.session import NonAnonymousLoginWithoutPassword, iRODSSession
+from irods.session import NonAnonymousLoginWithoutPassword
 import pytest
 
 from cubi_tk.irods_common import TransferJob, iRODSCommon, iRODSTransfer
@@ -94,7 +94,7 @@ def jobs():
 
 @pytest.fixture
 def itransfer(jobs):
-    with patch("cubi_tk.irods_common.iRODSSession") as mocksession:
+    with patch("cubi_tk.irods_common.iRODSSession"):
         return iRODSTransfer(jobs)
 
 

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -97,8 +97,14 @@ def test_irods_transfer_put(fs, itransfer, jobs):
 
 
 def test_irods_transfer_chksum(itransfer):
-    with patch.object(itransfer.session.data_objects, "get") as mock:
+    with patch.object(itransfer.session.data_objects, "get") as mockget:
+        mock_data_object = MagicMock()
+        mockget.return_value = mock_data_object
+        mock_data_object.checksum = None
+        mock_data_object.chksum = MagicMock()
+
         itransfer.chksum()
 
+        assert mock_data_object.chksum.call_count == len(itransfer.destinations)
         for path in itransfer.destinations:
-            mock.assert_any_call(path)
+            mockget.assert_any_call(path)

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -1,9 +1,7 @@
 from pathlib import Path
-import shutil
-from unittest.mock import ANY, call, MagicMock, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import irods.exception
-from irods.session import NonAnonymousLoginWithoutPassword
 import pytest
 
 from cubi_tk.irods_common import TransferJob, iRODSCommon, iRODSTransfer
@@ -22,6 +20,7 @@ def test_common_init(mocksession):
     assert icommon.irods_env_path == "a/b/c.json"
     assert type(iRODSCommon().ask) is bool
     assert iRODSCommon().session is mocksession.return_value
+
 
 @patch("cubi_tk.irods_common.iRODSSession")
 def test_get_irods_error(mocksession):

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -13,6 +13,7 @@ def test_transfer_job_bytes(fs):
     fs.create_file("test_file", st_size=123)
     assert TransferJob("test_file", "remote/path").bytes == 123
 
+
 @patch("cubi_tk.irods_common.iRODSSession")
 def test_common_init(mocksession):
     assert iRODSCommon().irods_env_path is not None

--- a/tests/test_irods_common.py
+++ b/tests/test_irods_common.py
@@ -14,20 +14,6 @@ def fake_filesystem(fs):
     yield fs
 
 
-@pytest.fixture
-def jobs():
-    return (
-        TransferJob(path_src="myfile.csv", path_dest="dest_dir/myfile.csv", bytes=123),
-        TransferJob(path_src="folder/file.csv", path_dest="dest_dir/folder/file.csv", bytes=1024),
-    )
-
-
-@pytest.fixture
-def itransfer(jobs):
-   with patch("irods.session.iRODSSession") as mocksession:
-       return iRODSTransfer(jobs)
-
-
 @patch("cubi_tk.irods_common.iRODSSession")
 def test_common_init(mocksession):
     assert iRODSCommon().irods_env_path is not None
@@ -95,6 +81,21 @@ def test_get_irods_sessions(mocksession):
         assert len(sessions) == 3
     with iRODSCommon()._get_irods_sessions(count=-1) as sessions:
         assert len(sessions) == 1
+
+
+# Test iRODSTransfer #########
+@pytest.fixture
+def jobs():
+    return (
+        TransferJob(path_src="myfile.csv", path_dest="dest_dir/myfile.csv", bytes=123),
+        TransferJob(path_src="folder/file.csv", path_dest="dest_dir/folder/file.csv", bytes=1024),
+    )
+
+
+@pytest.fixture
+def itransfer(jobs):
+    with patch("cubi_tk.irods_common.iRODSSession") as mocksession:
+        return iRODSTransfer(jobs)
 
 
 def test_irods_transfer_init(jobs, itransfer):


### PR DESCRIPTION
fixes #200 

- [x] add new class iRODSTransfer
- [x] put files to iRODS
- [x] trigger remote checksum computation
- [x] fix tests
- [x] also get files from iRODS
- [x] create common class with utility functions
- [x] use iRODS session manager implemented in irods.check
- [x] create sub-collections (recursive put)
- [x] rsync-like functionality (--sync?) which skips files present on remote
- [x] file progress as (n / n_total)
- [x] check if session is properly handled by contextmanager
- [x] handle `CAT_PASSWORD_EXPIRED` for long transfers

Note: Uploads cannot be cancelled by KeyboardInterrupt (caused by multiprocessing in irods client)