### PR TITLE
feat: Update ingest-fastq, allow to match samples against assay table to determine collections names (#198)

### DIFF
--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -390,7 +390,9 @@ class SnappyItransferCommandBase(ParseSampleSheet):
                 # Get uuid of lz that matches lz_path, this validates the path is correct & we have access
                 # validate that the LZ exists & user has access
                 try:
-                    lz_uuid = self.get_landing_zone_uuid_by_path(lz_irods_path, sodar_uuid, self.args.assay)
+                    lz_uuid = self.get_landing_zone_uuid_by_path(
+                        lz_irods_path, sodar_uuid, self.args.assay
+                    )
                 except requests.exceptions.HTTPError as e:
                     exception_str = str(e)
                     logger.error(

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -489,10 +489,10 @@ class SnappyItransferCommandBase(ParseSampleSheet):
             existing_lzs = list(filter(lambda x: x.assay == assay_uuid, existing_lzs))
 
         matching_lzs = list(filter(lambda x: x.irods_path == lz_irods_path, existing_lzs))
-        if matching_lzs:
+        if matching_lzs and matching_lzs[0].status == 'ACTIVE':
             lz_uuid = matching_lzs[0].sodar_uuid
         else:
-            msg = "Could not find LZ with given path. Please review input: {0}".format(
+            msg = "Could not find an active LZ with the given path. Please review input: {0}".format(
                 lz_irods_path
             )
             logger.error(msg)

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -190,15 +190,21 @@ class SnappyItransferCommandBase(ParseSampleSheet):
 
         toml_config = load_toml_config(args)
         if not args.sodar_url:
-            if toml_config:
-                args.sodar_url = toml_config.get("global", {}).get("sodar_server_url")
-            else:
+            if not toml_config:
+                logger.error("SODAR URL not found in config files. Please specify on command line.")
+                res = 1
+            args.sodar_url = toml_config.get("global", {}).get("sodar_server_url")
+            if not args.sodar_url:
                 logger.error("SODAR URL not found in config files. Please specify on command line.")
                 res = 1
         if not args.sodar_api_token:
-            if toml_config:
-                args.sodar_api_token = toml_config.get("global", {}).get("sodar_api_token")
-            else:
+            if not toml_config:
+                logger.error(
+                    "SODAR API token not found in config files. Please specify on command line."
+                )
+                res = 1
+            args.sodar_api_token = toml_config.get("global", {}).get("sodar_api_token")
+            if not args.sodar_api_token:
                 logger.error(
                     "SODAR API token not found in config files. Please specify on command line."
                 )
@@ -454,8 +460,8 @@ class SnappyItransferCommandBase(ParseSampleSheet):
 
     def get_landing_zone_uuid_by_path(self, lz_irods_path, project_uuid, assay_uuid=None):
         """
-        :param lz_path: Landing zone path.
-        :type lz_path: str
+        :param lz_irods_path: Landing zone path.
+        :type lz_irods_path: str
 
         :param project_uuid: Project UUID.
         :type project_uuid: str

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -489,11 +489,13 @@ class SnappyItransferCommandBase(ParseSampleSheet):
             existing_lzs = list(filter(lambda x: x.assay == assay_uuid, existing_lzs))
 
         matching_lzs = list(filter(lambda x: x.irods_path == lz_irods_path, existing_lzs))
-        if matching_lzs and matching_lzs[0].status == 'ACTIVE':
+        if matching_lzs and matching_lzs[0].status in ("ACTIVE", "FAILED"):
             lz_uuid = matching_lzs[0].sodar_uuid
         else:
-            msg = "Could not find an active LZ with the given path. Please review input: {0}".format(
-                lz_irods_path
+            msg = (
+                "Could not find an active LZ with the given path. Please review input: {0}".format(
+                    lz_irods_path
+                )
             )
             logger.error(msg)
             raise ParameterException(msg)

--- a/cubi_tk/snappy/itransfer_common.py
+++ b/cubi_tk/snappy/itransfer_common.py
@@ -171,7 +171,7 @@ class SnappyItransferCommandBase(ParseSampleSheet):
             "--assay", dest="assay", default=None, help="UUID of assay to download data for."
         )
         parser.add_argument(
-            "destination", help="UUID from Landing Zone or Project - where files will be moved to."
+            "destination", help="Landing zone path or UUID from Landing Zone or Project"
         )
 
     @classmethod

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -27,6 +27,7 @@ from ..snappy.itransfer_common import (
 
 DEFAULT_SRC_REGEX = (
     r"(.*/)?(?P<sample>.+?)"
+    r"(?:_(S[0-9]+)?"
     r"(?:_(?P<lane>L[0-9]+?))?"
     r"(?:_(?P<mate>R[0-9]+?))?"
     r"(?:_(?P<batch>[0-9]+?))?"
@@ -34,7 +35,7 @@ DEFAULT_SRC_REGEX = (
 )
 
 #: Default value for --dest-pattern
-DEFAULT_DEST_PATTERN = r"{collection_name}/{date}/{filename}"
+DEFAULT_DEST_PATTERN = r"{collection_name}/raw_data/{date}/{filename}"
 
 #: Default number of parallel transfers.
 DEFAULT_NUM_TRANSFERS = 8

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -191,7 +191,7 @@ class SodarIngestFastq(SnappyItransferCommandBase):
             sodar_api_token=self.args.sodar_api_token,
             landingzone_uuid=lz_uuid,
         )
-        return lz.sodar_uuid
+        return lz.project
 
     def build_base_dir_glob_pattern(self, library_name: str) -> typing.Tuple[str, str]:
         raise NotImplementedError(

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -244,7 +244,7 @@ class SodarIngestFastq(SnappyItransferCommandBase):
             for i, head in enumerate(assay_header)
             if head not in ignore_cols
             and in_column.lower()
-            in re.sub("(Parameter Value|Comment|Characteristics)\[", "", head).lower()
+            in re.sub("(Parameter Value|Comment|Characteristics)", "", head).lower()
         ]
         if not in_column_index or len(in_column_index) > 1:
             msg = "Could not identify a valid unique column of the assay sheet matching provided data. Please review input: --match-column={0}".format(

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -228,7 +228,7 @@ class SodarIngestFastq(SnappyItransferCommandBase):
         )
 
         assay_tsv = isa_dict["assays"][assay.file_name]["tsv"]
-        assay_header, *assay_lines = assay_tsv.split("\n")
+        assay_header, *assay_lines = assay_tsv.rstrip("\n").split("\n")
         assay_header = assay_header.split("\t")
         assay_lines = map(lambda x: x.split("\t"), assay_lines)
 

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -361,7 +361,8 @@ class SodarIngestFastq(SnappyItransferCommandBase):
         """Build file transfer jobs."""
         if library_names:
             logger.warning(
-                "will ignore parameter 'library_names' = %s in build_jobs()", str(library_names)
+                "will ignore parameter 'library_names' = %s in ingest_fastq.build_jobs()",
+                str(library_names),
             )
 
         lz_uuid, lz_irods_path = self.get_sodar_info()
@@ -373,9 +374,6 @@ class SodarIngestFastq(SnappyItransferCommandBase):
         else:
             column_match = None
 
-        # This collects input folders and downloads them if they are webdav locations
-        # Note: the webdav support here might not be documented. If useful it should maybe be
-        # made available for all itransfer commands.
         folders = self.download_webdav(self.args.sources)
         transfer_jobs = []
 
@@ -414,7 +412,7 @@ class SodarIngestFastq(SnappyItransferCommandBase):
                         remote_file = pathlib.Path(
                             lz_irods_path
                         ) / self.args.remote_dir_pattern.format(
-                            # Removed the `+ self.args.add_suffix` here, since anything after the file extension is a bad idea
+                            # Removed the `+ self.args.add_suffix` here, since adding anything after the file extension is a bad idea
                             filename=pathlib.Path(path).name,
                             date=self.args.remote_dir_date,
                             collection_name=column_match[sample_name]
@@ -424,13 +422,13 @@ class SodarIngestFastq(SnappyItransferCommandBase):
                         )
                     except KeyError:
                         msg = (
-                            f"Could not match extracted sample name '{sample_name}' to any value in the "
-                            "--match-column. Please review the assay table, src-regex and sample-collection-mapping args."
+                            f"Could not match extracted sample value '{sample_name}' to any value in the "
+                            f"--match-column {self.args.match_column}. Please review the assay table, src-regex and sample-collection-mapping args."
                         )
                         logger.error(msg)
                         raise ParameterException(msg)
 
-                    # This would the original code, but there is no need to change the remote file names once they are
+                    # This was the original code, but there is no need to change the remote file names once they are
                     # mapped to the correct collections:
                     # remote_file = str(remote_file)
                     # for m_pat, r_pat in self.args.remote_dir_mapping:

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -367,7 +367,7 @@ class SodarIngestFastq(SnappyItransferCommandBase):
                     )
 
                     # `-m` regex now only applied to extracted sample name
-                    sample_name = match_wildcards["sample"]
+                    sample_name = m.groupdict(default="")["sample"]
                     for m_pat, r_pat in self.args.sample_collection_mapping:
                         sample_name = re.sub(m_pat, r_pat, sample_name)
 

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -81,9 +81,10 @@ class SodarIngestFastq(SnappyItransferCommandBase):
             help="Assume the answer to all prompts is 'yes'",
         )
         parser.add_argument(
-            "--remote-dir-date",
-            default=datetime.date.today().strftime("%Y-%m-%d"),
-            help="Date to use in remote directory, defaults to YYYY-MM-DD of today.",
+            "--validate-and-move",
+            default=False,
+            action="store_true",
+            help="After files are transferred to SODAR, it will proceed with validation and move.",
         )
         parser.add_argument(
             "--src-regex",
@@ -100,7 +101,13 @@ class SodarIngestFastq(SnappyItransferCommandBase):
             "'sample' unless --match-column is not used to fill it from the assay table. Any capture group of the "
             "src-regex ('sample', 'lane', ...) can be used along with 'date' and 'filename'.",
         )
-
+        parser.add_argument(
+            "--match-column",
+            default=None,
+            help="Alternative assay column against which the {sample} from the src-regex should be matched, "
+            "in order to determine collections based on the assay table (e.g. last material or collection-column). "
+            "If not set it is assumed that {sample} matches the irods collections directly.",
+        )
         parser.add_argument(
             "-m",
             "--sample-collection-mapping",
@@ -118,32 +125,22 @@ class SodarIngestFastq(SnappyItransferCommandBase):
             "(i.e. '-m <regex1> <repl1> -m <regex2> <repl2>' ...).",
         )
         parser.add_argument(
-            "--tmp",
-            default="temp/",
-            help="Folder to save files from WebDAV temporarily, if set as source.",
+            "--remote-dir-date",
+            default=datetime.date.today().strftime("%Y-%m-%d"),
+            help="Date to use in remote directory, defaults to YYYY-MM-DD of today.",
         )
-
         parser.add_argument(
             "--collection-column",
             default=None,
             help="Assay column from that matchs irods collection names. "
             "If not set, the last material column will be used.",
         )
-
         parser.add_argument(
-            "--match-column",
-            default=None,
-            help="Alternative assay column against which the {sample} from the src-regex should be matched, "
-            "in order to determine collections based on the assay table (e.g. last material or collection-column). "
-            "If not set it is assumed that {sample} matches the irods collections directly.",
+            "--tmp",
+            default="temp/",
+            help="Folder to save files from WebDAV temporarily, if set as source.",
         )
 
-        parser.add_argument(
-            "--validate-and-move",
-            default=False,
-            action="store_true",
-            help="After files are transferred to SODAR, it will proceed with validation and move.",
-        )
         parser.add_argument("--assay", dest="assay", default=None, help="UUID of assay to use.")
 
         parser.add_argument("sources", help="paths to fastq folders", nargs="+")

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -27,7 +27,7 @@ from ..snappy.itransfer_common import (
 
 DEFAULT_SRC_REGEX = (
     r"(.*/)?(?P<sample>.+?)"
-    r"(?:_(S[0-9]+)?"
+    r"(?:_(S[0-9]+))?"
     r"(?:_(?P<lane>L[0-9]+?))?"
     r"(?:_(?P<mate>R[0-9]+?))?"
     r"(?:_(?P<batch>[0-9]+?))?"

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -339,7 +339,6 @@ class SodarIngestFastq(SnappyItransferCommandBase):
 
         for folder in folders:
             for path in glob.iglob(f"{folder}/**/*", recursive=True):
-
                 real_path = os.path.realpath(path)
                 if not os.path.isfile(real_path):
                     continue  # skip if did not resolve to file

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -255,6 +255,7 @@ class SodarIngestFastq(SnappyItransferCommandBase):
             )
             logger.error(msg)
             raise ParameterException(msg)
+        in_column_index = in_column_index[0]
 
         if out_column is None:
             # Get index of last material column that is not 'Raw Data File'
@@ -276,8 +277,9 @@ class SodarIngestFastq(SnappyItransferCommandBase):
                 )
                 logger.error(msg)
                 raise ParameterException(msg)
+            out_column_index = out_column_index[0]
 
-        return {line[in_column_index[0]]: line[out_column_index[0]] for line in assay_lines}
+        return {line[in_column_index]: line[out_column_index] for line in assay_lines}
 
     def download_webdav(self, sources):
         download_jobs = []

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -405,7 +405,7 @@ class SodarIngestFastq(SnappyItransferCommandBase):
                         transfer_jobs.append(
                             TransferJob(
                                 path_src=real_path + ext,
-                                path_dest=os.path.join(remote_file + ext),
+                                path_dest=str(remote_file) + ext,
                                 bytes=size,
                             )
                         )

--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -27,7 +27,7 @@ from ..snappy.itransfer_common import (
 
 DEFAULT_SRC_REGEX = (
     r"(.*/)?(?P<sample>.+?)"
-    r"(?:_(S[0-9]+))?"
+    r"(?:_S[0-9]+)?"
     r"(?:_(?P<lane>L[0-9]+?))?"
     r"(?:_(?P<mate>R[0-9]+?))?"
     r"(?:_(?P<batch>[0-9]+?))?"

--- a/docs_manual/man_ingest_fastq.rst
+++ b/docs_manual/man_ingest_fastq.rst
@@ -13,7 +13,8 @@ The basic usage is:
 
     $ cubi-tk sodar ingest-fastq SOURCE [SOURCE ...] DESTINATION
 
-where each ``SOURCE`` is a path to a folder containing relevant files and ``DESTINATION`` is either an iRODS path to a *landing zone* in SODAR or the UUID of that *landing zone*.
+where each ``SOURCE`` is a path to a folder containing relevant files (this can also be a WebDav URL, see below) and
+``DESTINATION`` is either an iRODS path to a *landing zone* in SODAR, the UUID of that *landing zone*, or and SODAR project UUID.
 
 ----------------
 Other file types
@@ -37,20 +38,25 @@ The default ``--remote-dir-pattern`` is
 
 .. code-block:: bash
 
-    {sample}/{date}/{filename}
+    {collection_name}/{date}/{filename}
 
-It contains the wildcard ``{sample}``, which will be filled with the captured content of group ``(?P<sample>...)``.
-In addition, the wildcards ``{date}`` and ``{filename}`` can always be used and will be filled with the current date and full filename (the basename of a matched file), respectively.
+It contains the wildcard ``{collection_name}``, which represents and irods collection and will be filled with the captured
+content of group ``(?P<sample>...)``, potentially modified by a regex (see 'Mapping of file names' below).
+Alternatively the irods collection name can be derived by mapping the extracted (and modified) ``(?P<sample>...)``
+group to any column of the assay table associated with the LZ or project. In this case the ``{library_name}`` will be
+filled with the content of the last material column of the assay table (or ``--collection-column`` if defined).
+In addition, the wildcards ``{date}`` and ``{filename}`` can always be used in ``--remote-dir-pattern`` and will be
+filled with the current date (or ``--remote-dir-date``) and full filename (the basename of a matched file), respectively.
 
 ---------------------
 Mapping of file names
 ---------------------
 
-In some cases additional mapping of filenames is required (for example the samples should be renamed).
-This can be done via the parameter ``--remote-dir-mapping`` or short ``-m``.
+In some cases additional mapping of filenames is required (for example to fully macth the irods collections).
+This can be done via the parameter ``--sample-collection-mapping`` or short ``-m``.
 It can be supplied several times, each time for another mapping.
 With each ``-m MATCH REPL`` a pair of a regular expression and a replacement string are specified.
-Internally, pythons ``re.sub`` command is executed on the ``--remote-dir-pattern`` after wildcards have been filled.
+Internally, pythons ``re.sub`` command is executed on the extracted ``(?P<sample>...)`` capture group.
 Therefore, you can refer to the documentation of the `re package <https://docs.python.org/3/library/re.html>`_ for syntax questions.
 
 ----------------------
@@ -70,8 +76,7 @@ To use this command, which internally executes iRODS icommands, you need to auth
 
     $ iinit
 
-To be able to access the SODAR API (which is only required, if you specify a landing zone UUID instead of an iRODS path), you also need an API token.
-For token management for SODAR, the following docs can be used:
+To be able to access the SODAR API you also need an API token. For token management for SODAR, the following docs can be used:
 
 - https://sodar.bihealth.org/manual/ui_user_menu.html
 - https://sodar.bihealth.org/manual/ui_api_tokens.html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,3 +74,26 @@ def my_exists(self):
 def my_get_sodar_info(_self):
     """Method is used to patch cubi_tk.snappy.itransfer_common.SnappyItransferCommandBase.get_sodar_info"""
     return "466ab946-ce6a-4c78-9981-19b79e7bbe86", "/irods/dest"
+
+
+def my_sodar_api_export(n_assays=1):
+    """Return contents for api.samplesheet.export"""
+    assay = textwrap.dedent(
+        """
+        Sample Name\tProtocol REF\tParameter Value[Concentration measurement]\tPerformer\tDate\tExtract Name\tCharacteristics[Concentration]\tUnit\tTerm Source REF\tTerm Accession Number\tProtocol REF\tParameter Value[Provider name]\tParameter Value[Provider contact]\tParameter Value[Provider project ID]\tParameter Value[Provider sample ID]\tParameter Value[Provider QC status]\tParameter Value[Requestor contact]\tParameter Value[Requestor project]\tParameter Value[Requestor sample ID]\tParameter Value[Concentration measurement]\tParameter Value[Library source]\tParameter Value[Library strategy]\tParameter Value[Library selection]\tParameter Value[Library layout]\tParameter Value[Library kit]\tComment[Library kit catalogue ID]\tParameter Value[Target insert size]\tParameter Value[Wet-lab insert size]\tParameter Value[Barcode kit]\tParameter Value[Barcode kit catalogue ID]\tParameter Value[Barcode name]\tParameter Value[Barcode sequence]\tPerformer\tDate\tLibrary Name\tCharacteristics[Folder name]\tCharacteristics[Concentration]\tUnit\tTerm Source REF\tTerm Accession Number\tProtocol REF\tParameter Value[Platform]\tParameter Value[Instrument model]\tParameter Value[Base quality encoding]\tParameter Value[Center name]\tParameter Value[Center contact]\tPerformer\tDate\tRaw Data File
+        Sample1-N1\tNucleic acid extraction WES\t\t\t\tSample1-N1-DNA1\t\t\t\t\tLibrary construction WES\t\t\t\t\t\t\t\t\t\tGENOMIC\tWXS\tHybrid Selection\tPAIRED\tAgilent SureSelect Human All Exon V7\t\t\t\t\t\t\t\t\t\tSample1-N1-DNA1-WES1\tFolder1\t\t\t\t\tNucleic acid sequencing WES\tILLUMINA\tIllumina NovaSeq 6000\tPhred+33
+        Sample2-N1\tNucleic acid extraction WES\t\t\t\tSample2-N1-DNA1\t\t\t\t\tLibrary construction WES\t\t\t\t\t\t\t\t\t\tGENOMIC\tWXS\tHybrid Selection\tPAIRED\tAgilent SureSelect Human All Exon V7\t\t\t\t\t\t\t\t\t\tSample2-N1-DNA1-WES1\tFolder2\t\t\t\t\tNucleic acid sequencing WES\tILLUMINA\tIllumina NovaSeq 6000\tPhred+33
+        Sample3-N1\tNucleic acid extraction WES\t\t\t\tSample3-N1-DNA1\t\t\t\t\tLibrary construction WES\t\t\t\t\t\t\t\t\t\tGENOMIC\tWXS\tHybrid Selection\tPAIRED\tAgilent SureSelect Human All Exon V7\t\t\t\t\t\t\t\t\t\tSample3-N1-DNA1-WES1\tFolder3\t\t\t\t\tNucleic acid sequencing WES\tILLUMINA\tIllumina NovaSeq 6000\tPhred+33
+        """
+    ).lstrip()
+
+    isa_dict = {
+        "investigation": {"path": "i_Investigation.txt", "tsv": None},
+        "studies": {"s_Study_0.txt": {"tsv": None}},
+        "assays": {"a_name_0": {"tsv": assay}},
+    }
+    if n_assays > 1:
+        for i in range(1, n_assays):
+            isa_dict["assays"]["a_name_%d" % i] = {"tsv": assay}
+
+    return isa_dict

--- a/tests/test_sodar_ingest_fastq.py
+++ b/tests/test_sodar_ingest_fastq.py
@@ -11,6 +11,7 @@ from pyfakefs import fake_filesystem, fake_pathlib
 import pytest
 
 from cubi_tk.__main__ import main, setup_argparse
+from .conftest import my_get_sodar_info
 
 
 def test_run_sodar_ingest_fastq_help(capsys):
@@ -41,7 +42,7 @@ def test_run_sodar_ingest_fastq_nothing(capsys):
 def test_run_sodar_ingest_fastq_smoke_test(mocker, requests_mock):
     # --- setup arguments
     irods_path = "/irods/dest"
-    landing_zone_uuid = "landing_zone_uuid"
+    landing_zone_uuid = "466ab946-ce6a-4c78-9981-19b79e7bbe86"
     dest_path = "target/folder/generic_file.fq.gz"
     fake_base_path = "/base/path"
     argv = [
@@ -86,9 +87,11 @@ def test_run_sodar_ingest_fastq_smoke_test(mocker, requests_mock):
 
     # --- mock modules
     mocker.patch("glob.os", fake_os)
-    mocker.patch("cubi_tk.sea_snap.itransfer_results.pathlib", fake_pl)
-    mocker.patch("cubi_tk.sea_snap.itransfer_results.os", fake_os)
     mocker.patch("cubi_tk.snappy.itransfer_common.os", fake_os)
+    mocker.patch(
+        "cubi_tk.snappy.itransfer_common.SnappyItransferCommandBase.get_sodar_info",
+        my_get_sodar_info,
+    )
 
     mock_check_output = mock.MagicMock(return_value=0)
     mocker.patch("cubi_tk.snappy.itransfer_common.check_output", mock_check_output)

--- a/tests/test_sodar_ingest_fastq.py
+++ b/tests/test_sodar_ingest_fastq.py
@@ -5,6 +5,7 @@ We only run some smoke tests here.
 
 import json
 import os
+import re
 from unittest import mock
 
 from pyfakefs import fake_filesystem, fake_pathlib
@@ -38,6 +39,22 @@ def test_run_sodar_ingest_fastq_nothing(capsys):
     res = capsys.readouterr()
     assert not res.out
     assert res.err
+
+
+def test_run_sodar_ingest_fastq_src_regex():
+    from cubi_tk.sodar.ingest_fastq import DEFAULT_SRC_REGEX
+
+    # Collection of example filenames and the expected {sample} value the regex should capture
+    test_filenames = {
+        "Sample1-N1-RNA1-RNA_seq1.fastq.gz": "Sample1-N1-RNA1-RNA_seq1",
+        "P1234_Samplename_S14_L006_R2_001.fastq.gz": "P1234_Samplename",
+        "P1234_Samplename2_R1.fastq.gz": "P1234_Samplename2",
+    }
+
+    for test_filename, expected_sample in test_filenames.items():
+        res = re.match(DEFAULT_SRC_REGEX, test_filename)
+        assert res is not None
+        assert res.groupdict()["sample"] == expected_sample
 
 
 def test_run_sodar_ingest_fastq_smoke_test(mocker, requests_mock):

--- a/tests/test_sodar_ingest_fastq.py
+++ b/tests/test_sodar_ingest_fastq.py
@@ -11,6 +11,7 @@ from pyfakefs import fake_filesystem, fake_pathlib
 import pytest
 
 from cubi_tk.__main__ import main, setup_argparse
+
 from .conftest import my_get_sodar_info
 
 


### PR DESCRIPTION
This was initially only intended to solve #198 , but I ended up adding some additional changes / enhancements to other aspects of `cubi-tk sodar ingest-fastq` and other (`cubi-tk snappy itransfer` functions).

Added Features:

- Added the `--match-column` flag that enables comparing the contents of the  "(?<sample>?)" match group from the src-regex against any specified column of the assay table of a given project (automatically determined from destination) to determine the (new) 'collection_name' parameter in the destination pattern based on the last material column of the assay (or alternatively another column given via `--collection-column`). If this is not used the "(?<sample>?)" match group is assumed to equal the irods collection names (this mirrors previous behaviour).
- The `cubi-tk snappy itransfer` can now take a LZ_path as destination (this was intended based on descriptions in the code but never implemented)
- `cubi-tk sodar ingest-fastq` now fully inherits the possibility of using an LZ_path, LZ_UUID or Sodar porject UUID as a destination from the `cubi-tk snappy itransfer` functions 
- `cubi-tk sodar ingest-fastq` similarly inherits the possibility to automatically validate & move landing zones


Changed Features:

- Renamed the `-m`flag from `--remote-dir-mapping` to `--sample-collection-mapping` and slightly reduced its scope. Previously this allowed applying a regex to the complete remote irods path (and could in-fact make the path non-viable), which allowed adapting the extracted sample/collection name but also renamed the remote files. Now the regex is applied **only** to extracted "(?<sample>?)" match group that determines the collection name (either directly or by matching the final modified values to an assay table column). 
- Changed the default_src_regex to omit the sample barcode (_S[0-9]+_) from the sample name (this should fix #4 )
- Changed the default destination pattern to include "raw_data" (`{collection_name}/raw_data/{date}/{filename}` instead of `{sample}/{date}/{filename}`)

Removed Features:

- removed `--add-suffix` flag since it's only use was adding a string to the end (i.e. after file ending) of the remote filename. This seemed like unwanted behavior to me and the remote filepaths can otherwise be controlled by `--remote-dir-pattern`. Renaming of files inside the remote patterns also does not seem to serve any useful purpose.
- removed unused `--basepath` flag