### PR TITLE
feat: Switching `cubi-tk sodar ingest-fastq` from icommands to irods_common

### DIFF
--- a/cubi_tk/sodar/ingest_fastq.py
+++ b/cubi_tk/sodar/ingest_fastq.py
@@ -505,8 +505,6 @@ class SodarIngestFastq(SnappyItransferCommandBase):
         for job in transfer_jobs:
             output_logger.info(job.path_local)
         logger.info(f"With a total size of {sizeof_fmt(itransfer.size)}")
-        # logger.info("Into this iRODS collection:")
-        # output_logger.info(f"{self.target_coll}/")
 
         if not self.args.yes:
             if not input("Is this OK? [y/N] ").lower().startswith("y"):  # pragma: no cover


### PR DESCRIPTION
Note: in the future the `SnappyItransferCommandBase` class should be changed to directly use the iRODSCommon functions for uplods, however that will need more work, so I"m only doing the necessary changes here for now.