### PR TITLE
feat: allow varfish case resubmission

### DIFF
--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -4,11 +4,11 @@ import argparse
 import glob
 import os
 import pathlib
+from subprocess import check_call
 import typing
 
 from biomedsheets import shortcuts
 from logzero import logger
-from subprocess import check_call
 
 from ..common import find_base_path
 from .common import load_sheet_tsv

--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -143,6 +143,13 @@ class SnappyVarFishUploadCommand:
             help="Assume yes to all answers",
         )
         parser.add_argument(
+            "--force-resubmit",
+            "-f",
+            action="store_true",
+            required=False,
+            help="Force re-submission of exitsing cases in varfish.",
+        )
+        parser.add_argument(
             "--samples",
             help=(
                 "Limits the submission to the listed sample names. Don't include the full library name just the "
@@ -271,6 +278,7 @@ class SnappyVarFishUploadCommand:
                 "--verbose",
                 "importer",
                 "caseimportinfo-create",
+                "--resubmit" if self.args.force_resubmit else "",
                 sodar_uuid,
                 *sorted(found.values()),
             ]

--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -269,8 +269,8 @@ class SnappyVarFishUploadCommand:
                 "varfish-cli",
                 "--no-verify-ssl",
                 "--verbose",
-                "case",
-                "create-import-info",
+                "importer",
+                "caseimportinfo-create",
                 sodar_uuid,
                 *sorted(found.values()),
             ]

--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -8,7 +8,7 @@ import typing
 
 from biomedsheets import shortcuts
 from logzero import logger
-from varfish_cli.__main__ import main as varfish_cli_main
+from subprocess import check_call
 
 from ..common import find_base_path
 from .common import load_sheet_tsv
@@ -284,7 +284,7 @@ class SnappyVarFishUploadCommand:
                 answer = answer_str == "y"
             if answer:
                 logger.info("Executing '%s'", " ".join(args))
-                varfish_cli_main(args[1:])
+                check_call(args)
         logger.info("  -> all done with %s", name)
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,7 +52,7 @@ argcomplete
 pyyaml
 
 # VarFish REST API client.
-varfish-cli >=0.5.1
+varfish-cli >=0.6.2,<=0.7.0
 
 # Compact, round-tripable configuration format.
 toml

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,7 +52,7 @@ argcomplete
 pyyaml
 
 # VarFish REST API client.
-varfish-cli >=0.6.2,<=0.7.0
+varfish-cli >=0.6.2,<0.7.0
 
 # Compact, round-tripable configuration format.
 toml


### PR DESCRIPTION
Previous varfish-cli versions always allowed case resubmission, the new 0.6.2 version does not do this by default, so we need the extra option in cubi-tk.

(I'm not sure why git thinks these other commits are part of this, they are already merged into main as of #222 )