### PR TITLE
fix: varfish-upload subprocess submission

### DIFF
--- a/cubi_tk/snappy/varfish_upload.py
+++ b/cubi_tk/snappy/varfish_upload.py
@@ -278,7 +278,7 @@ class SnappyVarFishUploadCommand:
                 "--verbose",
                 "importer",
                 "caseimportinfo-create",
-                "--resubmit" if self.args.force_resubmit else "",
+                "--resubmit" if self.args.force_resubmit else "--no-resubmit",
                 sodar_uuid,
                 *sorted(found.values()),
             ]


### PR DESCRIPTION
Fix needed for #224 , the empty sting given to subprocess causes problems - using proper cmd line flag instead.