### PR TITLE
fix: relax python-irodsclient pin to >=3.1.1,<3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "icdiff>=2.0.7",
     "loguru>=0.7.3",
     "pandas>=2.2.3",
-    "python-irodsclient==3.1.0",
+    "python-irodsclient>=3.1.1,<3.2",
     "pyyaml>=6.0.2",
     "requests>=2.32.3",
     "retrying>=1.3.4",

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ requires-dist = [
     { name = "icdiff", specifier = ">=2.0.7" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pandas", specifier = ">=2.2.3" },
-    { name = "python-irodsclient", specifier = "==3.1.0" },
+    { name = "python-irodsclient", specifier = ">=3.1.1,<3.2" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "retrying", specifier = ">=1.3.4" },
@@ -1001,15 +1001,15 @@ wheels = [
 
 [[package]]
 name = "python-irodsclient"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "defusedxml" },
     { name = "prettytable" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/a3/5771c33ab6be10ffd07869989c5528db9a315be01f39b51bed0f77d6754a/python_irodsclient-3.1.0.tar.gz", hash = "sha256:e5734de7ec0af6612a28b605215ab92cc0ded3c0a73803de595f0128e2cd609e", size = 290079 }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/04/79fff7ef2ad0c16b20b35ad4177d4fdd872408114ae28a225b593737f5d3/python-irodsclient-3.1.1.tar.gz", hash = "sha256:e44e2aa0246d12057a68f69f4eb6ade08ffa60b0e0d86783bebc9f663513efde", size = 298027 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a2/d2df01859afa8788a87e2d3d008bd11e0e3263a96e95f482998fb5d5b856/python_irodsclient-3.1.0-py3-none-any.whl", hash = "sha256:3f54ba512cb151a0d6de22c2f2bdc1d7d946f3abc76eac9d0e6e11b1b19c8060", size = 263876 },
+    { url = "https://files.pythonhosted.org/packages/4d/71/95f7115a6e2e2b44b4cebfc833f95ad165790a8a3a41bb929cd051c6740f/python_irodsclient-3.1.1-py3-none-any.whl", hash = "sha256:ad1534d03acf3062337eaa00709534c5eb3a3a2c57b2ea43e12293fcca94c4b2", size = 268523 },
 ]
 
 [[package]]


### PR DESCRIPTION
# PR draft — bihealth/cubi-tk

**Base:** `main` @ `f659c41`
**Branch:** `relax-python-irodsclient-pin`
**Patch:** `cubi-tk-relax-irodsclient.patch`

---

## PR title (Conventional Commits — enforced by `conventional-prs.yml`)

```
fix: relax python-irodsclient pin to >=3.1.1,<3.2
```

> `conventional-prs.yml` sets `validateSingleCommit: true`, so squash to one
> commit and use the same message as the PR title.

---

## PR body

### Summary

`python-irodsclient` is pinned to exactly `==3.1.0`. That version is
blacklisted by iBridges, which makes cubi-tk and iBridges impossible to install
into the same environment. This relaxes the pin to `>=3.1.1,<3.2`.

### Why 3.1.0 specifically is a problem

iBridges excludes exactly this release:

```
# ibridges >= 1.5.1
Requires-Dist: python-irodsclient!=3.1.0,<3.2.0,>=2.0.0
```

It was added in UtrechtUniversity/ibridges@0ffb123, *"Blacklist PRC==3.1.0
since it gives import errors"*, with the note that 3.1.1 would be released
shortly. 3.1.1 is the bugfix release for exactly that problem.

Because cubi-tk requires `==3.1.0` and iBridges requires `!=3.1.0`, pip cannot
resolve the two together:

```
The conflict is caused by:
    workflow-core 0.0.0 depends on python-irodsclient<3.2 and >=3.1.1
    cubi-tk 0.7.0 depends on python-irodsclient==3.1.0
ERROR: ResolutionImpossible
```

This blocks our MVH workflow packages (`workflows-core`, `sequencing-qc`,
`grz-workflow`, `mvh-entry-overview`), which need cubi-tk and iBridges in one
environment. The only workaround today is holding iBridges back to `<1.5.1`,
which means giving up its bugfixes indefinitely.

### Why the exact pin isn't needed

`==3.1.0` was carried over verbatim from `requirements/base.txt` in the
pyproject migration (#241) — the old file pinned `==1.1.8` in the same style.
It encodes a frozen requirement, not a known incompatibility.

cubi-tk uses only long-stable python-irodsclient APIs:

```python
from irods.client_init import write_pam_irodsA_file
from irods.collection import iRODSCollection
from irods.column import Like
from irods.data_object import iRODSDataObject
from irods.keywords import FORCE_FLAG_KW
from irods.models import Collection, DataObject
from irods.session import iRODSSession
import irods.exception
```

All are unchanged between 3.1.0 and 3.1.1 — the two releases have identical
dependency metadata, and 3.1.1 is a pure bugfix for the import problem.

The `<3.2` upper bound is kept so this stays a minimal change; 3.2 can be
evaluated separately.

### Testing

Full suite, Python 3.12, via the CI commands (`uv sync --all-extras
--all-groups` + `uv run pytest`):

| python-irodsclient | Result |
|---|---|
| 3.1.0 (before) | 158 passed |
| 3.1.1 (after)  | 158 passed |

No behavioural difference.

### Changes

- `pyproject.toml`: `python-irodsclient==3.1.0` → `>=3.1.1,<3.2`
- `uv.lock`: regenerated (`uv lock`), resolving `python-irodsclient` 3.1.0 → 3.1.1

> The lock was regenerated with **uv 0.5.31** to match the format of the
> committed `uv.lock` (`version = 1`). Newer uv releases rewrite the whole file
> (lock `revision = 3`, `upload-time` on every entry), producing ~1000 lines of
> unrelated churn.

---

## Commands to open it

```bash
cd <your cubi-tk checkout>
git checkout -b relax-python-irodsclient-pin f659c41
git apply /path/to/cubi-tk-relax-irodsclient.patch
git commit -am "fix: relax python-irodsclient pin to >=3.1.1,<3.2"
git push -u origin relax-python-irodsclient-pin
gh pr create --title "fix: relax python-irodsclient pin to >=3.1.1,<3.2" --body-file cubi-tk-PR.md
```

## Note on the commit type

`fix:` will make release-please cut a patch release, which is what you want —
downstream can then depend on a released cubi-tk instead of a commit hash. If
you'd rather not trigger a release, use `chore(deps): ...` instead; release-please
ignores it, and you keep pinning cubi-tk by commit hash as
`mvh-entry-overview` does today.

## Follow-up once this is merged

`workflows-core` and `grz-workflow` currently cap `ibridges >=1.4,<1.5.1` to
work around this. After merging and bumping the cubi-tk pin in
`mvh-entry-overview`, both can go back to `ibridges >=1.4,<2`.
